### PR TITLE
棒読みちゃんへ送る文字列にプレフィックスをつけられるようにした

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -62,7 +62,7 @@
               <span>http://localhost:</span>
               <input id="text-port-number" class="mdl-textfield__input" type="text" required="true" pattern="[0-9]{0,4}?" value="3000" />
             </div>
-            <span class="mdl-textfield__error">0-9999 までの数値を入れてください</span>  
+            <span class="mdl-textfield__error">0-9999 までの数値を入れてください</span>
           </div>
           <div>
             <span id="server-full-url"></span>
@@ -77,7 +77,7 @@
               <div class="caption">サーバ起動中に変更した場合は、最新の1レスがコメント欄に表示されます。</div>
               <div>
                 <span class="status" id="bbs-title"></span>
-              </div>              
+              </div>
               <input id="text-url" class="mdl-textfield__input" type="text" pattern="http.?://.+/$" value="" />
               <span id="text-url-error" class="mdl-textfield__error">URLを入力してください</span>
             </div>
@@ -304,6 +304,10 @@
             <p style="width: 80%;">
               <input id="bouyomi-volume" class="mdl-slider mdl-js-slider" type="range" min="-1" max="100" value="50" tabindex="0" oninput="showVal('disp-bouyomi-volume', this.value)" />
             </p>
+          </div>
+          <div class="mdl-textfield mdl-js-textfield" style="width: 600px;">
+            <div class="subtitle">プレフィックス</div>
+            <input class="mdl-textfield__input" type="text" id="text-bouyomi-prefix" />
           </div>
 
           <h5>その他の読み子設定</h5>

--- a/src/main/bouyomi-chan/index.ts
+++ b/src/main/bouyomi-chan/index.ts
@@ -7,6 +7,7 @@ type Options = {
   tone?: number;
   volume?: number;
   type?: number;
+  prefix?: string;
 };
 
 class BouyomiChan {
@@ -18,6 +19,7 @@ class BouyomiChan {
     if (options.tone) this.tone = options.tone;
     if (options.volume) this.volume = options.volume;
     if (options.type) this.type = options.type;
+    if (options.prefix) this.prefix = options.prefix;
   }
 
   /**
@@ -46,12 +48,19 @@ class BouyomiChan {
   private type = 0;
 
   /**
+   * 読み上げの際先頭に付加する文字列
+   */
+  private prefix = '';
+
+  /**
    * @param message 棒読みちゃんに読み上げてもらう文章
    */
   speak(message: string) {
+    /** 読み前に文字列を処理する */
+    const concatMessage = this.prefix.concat(message);
     /** 棒読みちゃんに送信する設定のバイト長 */
     const SETTINGS_BYTES_LENGTH = 15;
-    const messageByteLength = Buffer.byteLength(message);
+    const messageByteLength = Buffer.byteLength(concatMessage);
     const bufferLength = SETTINGS_BYTES_LENGTH + messageByteLength;
     const buff = Buffer.alloc(bufferLength);
     /** メッセージ読み上げコマンド */
@@ -65,7 +74,7 @@ class BouyomiChan {
     const ENCODING = 0;
     len = buff.writeUInt8(ENCODING, len);
     len = buff.writeUInt32LE(messageByteLength, len);
-    len = buff.write(message, len);
+    len = buff.write(concatMessage, len);
 
     const client = net.createConnection(this.port, this.host);
     client.write(buff);

--- a/src/main/startServer.ts
+++ b/src/main/startServer.ts
@@ -217,7 +217,7 @@ ipcMain.on(electronEvent.START_SERVER, async (event: any, config: typeof globalT
   // 棒読みちゃん接続
   if (config.typeYomiko === 'bouyomi') {
     if (config.bouyomiPort) {
-      bouyomi = new bouyomiChan({ port: config.bouyomiPort, volume: config.bouyomiVolume });
+      bouyomi = new bouyomiChan({ port: config.bouyomiPort, volume: config.bouyomiVolume, prefix: config.bouyomiPrefix });
     }
   }
 

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -219,6 +219,7 @@ const buildConfigJson = () => {
   const tamiyasuPath = (document.getElementById('text-tamiyasu-path') as HTMLInputElement).value;
   const bouyomiPort = parseInt((document.getElementById('text-bouyomi-port') as HTMLInputElement).value);
   const bouyomiVolume = parseInt((document.getElementById('bouyomi-volume') as HTMLInputElement).value);
+  const bouyomiPrefix = (document.getElementById('text-bouyomi-prefix') as HTMLInputElement).value;
   const yomikoReplaceNewline = (document.getElementById('yomiko-replace-newline') as any).checked === true;
 
   const notifyThreadConnectionErrorLimit = parseInt((document.getElementById('text-notify-threadConnectionErrorLimit') as HTMLInputElement).value);
@@ -296,6 +297,7 @@ const buildConfigJson = () => {
     tamiyasuPath,
     bouyomiPort,
     bouyomiVolume,
+    bouyomiPrefix,
     yomikoReplaceNewline,
     notifyThreadConnectionErrorLimit,
     notifyThreadResLimit,
@@ -347,6 +349,7 @@ const loadConfigToLocalStrage = () => {
     tamiyasuPath: '',
     bouyomiPort: 50001,
     bouyomiVolume: 50,
+    bouyomiPrefix: '',
     yomikoReplaceNewline: false,
     notifyThreadConnectionErrorLimit: 0,
     notifyThreadResLimit: 0,
@@ -440,6 +443,7 @@ const loadConfigToLocalStrage = () => {
   (document.getElementById('text-tamiyasu-path') as any).value = config.tamiyasuPath;
   (document.getElementById('text-bouyomi-port') as any).value = config.bouyomiPort;
   (document.getElementById('disp-bouyomi-volume') as any).innerHTML = config.bouyomiVolume;
+  (document.getElementById('text-bouyomi-prefix') as any).value = config.bouyomiPrefix;
   (document.getElementById('bouyomi-volume') as any).value = config.bouyomiVolume;
   (document.getElementById('text-notify-threadConnectionErrorLimit') as any).value = config.notifyThreadConnectionErrorLimit;
   (document.getElementById('text-notify-threadResLimit') as any).value = config.notifyThreadResLimit;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -92,6 +92,8 @@ declare global {
     let bouyomiPort: number;
     /** 棒読みちゃんの音量 */
     let bouyomiVolume: number;
+    /** 棒読みちゃんへ送るときのプレフィックス */
+    let bouyomiPrefix: string;
     /** 読み子へ渡す時に改行を置換 */
     let yomikoReplaceNewline: boolean;
     /** スレが通信エラーになった時の通知閾値 */


### PR DESCRIPTION
## 動機

棒読みちゃんにはVoiceroid Talk Plusというプラグインがあります。このプラグインはVOICEROIDシリーズに読み上げを流すために必要なものなのですが、読み上げ文字列の先頭にプラグイン側の設定で指定した文字列を付加することで読み上げる子を指定することが出来ます。

通常のunacastの動作では、このプラグインを他のプログラムから同時に使用する場合個別に読み上げる音声を指定できないので、この変更によって読み上げる音声を自在に指定することが出来ます。

## 実装

設定にprefixを指定する項目を加え、棒読みちゃんの初期化をする際にそのprefixを渡し、実際に読み上げる際にprefixを付加した文字列を読み上げるようにしています。

初期状態ではprefixは何も無い状態なので読み上げ文字列は変わりません。

