### PR TITLE
Twitchのエモートの表示サイズ、アニメの有無を設定できるようにした。

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -260,6 +260,26 @@
           <input id="min-display-time" class="mdl-textfield__input" type="text" required="true" pattern="[0-9]+(\.[0-9])?" value="2.5" />
           <span class="mdl-textfield__error">X.Y秒で入力してください</span>
         </div>
+
+        <div class="mdl-textfield mdl-js-textfield" style="width: 100%;">
+          <div class="subtitle">Twitchエモートの表示設定</div>
+          <label class="mdl-radio mdl-js-radio" for="emoteSize_1">
+            <input id="emoteSize_1" class="mdl-radio__button" type="radio" name="emoteSize" value="1" />
+            <span class="mdl-radio__label">サイズ小</span>
+          </label>
+          <label class="mdl-radio mdl-js-radio" for="emoteSize_2">
+            <input id="emoteSize_2" class="mdl-radio__button" type="radio" name="emoteSize" value="2" />
+            <span class="mdl-radio__label">サイズ中</span>
+          </label>
+          <label class="mdl-radio mdl-js-radio" for="emoteSize_3">
+            <input id="emoteSize_3" class="mdl-radio__button" type="radio" name="emoteSize" value="3" />
+            <span class="mdl-radio__label">サイズ大</span>
+          </label>
+          <label class="mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect" for="checkbox-emoteAnimation">
+            <input type="checkbox" id="checkbox-emoteAnimation" class="mdl-checkbox__input" value="1" checked />
+            <span class="mdl-checkbox__label">アニメーション表示</span>
+          </label>
+        </div>
       </div>
 
       <div class="block">

--- a/src/main/startServer.ts
+++ b/src/main/startServer.ts
@@ -330,9 +330,15 @@ const startTwitchChat = async () => {
       const name = escapeHtml(msg.displayName);
       let text = escapeHtml(msg.messageText);
       // エモートを画像タグにする
-      msg.emotes.map((emote) => {
-        text = text.replace(emote.code, `<img src="https://static-cdn.jtvnw.net/emoticons/v1/${emote.id}/1.0" />`);
-      });
+      if (globalThis.config.emoteAnimation) {
+        msg.emotes.map((emote) => {
+          text = text.replace(emote.code, `<img src="https://static-cdn.jtvnw.net/emoticons/v2/${emote.id}/default/light/${globalThis.config.emoteSize}.0" />`);
+        });
+      } else {
+        msg.emotes.map((emote) => {
+          text = text.replace(emote.code, `<img src="https://static-cdn.jtvnw.net/emoticons/v1/${emote.id}/${globalThis.config.emoteSize}.0" />`);
+        });
+      }
 
       globalThis.electron.commentQueueList.push({ imgUrl, name, text, from: 'twitch' });
     });

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -266,6 +266,15 @@ const buildConfigJson = () => {
   });
   const hideImgUrl = (document.getElementById('checkbox-hideImgUrl') as any).checked === true;
 
+  // エモート表示
+  const emoteAnimation = (document.getElementById('checkbox-emoteAnimation') as HTMLInputElement).checked === true;
+  
+  let emoteSize: typeof globalThis['config']['emoteSize'] = 1;
+  document.getElementsByName('emoteSize').forEach((v) => {
+    const elem = v as HTMLInputElement;
+    if (elem.checked) emoteSize = Number(elem.value) as typeof globalThis['config']['emoteSize'];
+  });
+
   let typeYomiko: typeof globalThis['config']['typeYomiko'] = 'none';
   document.getElementsByName('typeYomiko').forEach((v) => {
     const elem = v as HTMLInputElement;
@@ -334,6 +343,8 @@ const buildConfigJson = () => {
     wordBreak,
     thumbnail,
     hideImgUrl,
+    emoteAnimation,
+    emoteSize,
     sePath,
     playSe,
     playSeVolume,
@@ -390,6 +401,8 @@ const loadConfigToLocalStrage = () => {
     wordBreak: true,
     thumbnail: 0,
     hideImgUrl: false,
+    emoteAnimation: false,
+    emoteSize: 1,
     sePath: '',
     playSeVolume: 100,
     playSe: false,
@@ -471,6 +484,10 @@ const loadConfigToLocalStrage = () => {
   // サムネイル表示
   (document.getElementById(`thumbnail_${config.thumbnail}`) as any).checked = true;
   (document.getElementById('checkbox-hideImgUrl') as any).checked = config.hideImgUrl;
+
+  // エモート表示
+  (document.getElementById('checkbox-emoteAnimation') as any).checked = config.emoteAnimation;
+  (document.getElementById(`emoteSize_${config.emoteSize}`) as any).checked = config.emoteSize;
 
   (document.getElementById('yomiko-replace-newline') as any).checked == config.yomikoReplaceNewline;
 

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -88,6 +88,9 @@ declare global {
      */
     let thumbnail: 0 | 1 | 2;
     let hideImgUrl: boolean;
+    /** エモートの表示設定 */
+    let emoteAnimation: boolean;
+    let emoteSize: 1 | 2 | 3;
     /** レス着信音のパス */
     let sePath: string;
     /** レス着信音再生 */


### PR DESCRIPTION
Twitchでのエモート表示のサイズが固定だったのを、3サイズから選択できるようにしました。
また、エモートのimg URLがv1（アニメ無し）固定だったのを、v2（アニメ有り）を選択できるようにしました。
![emoteSetting](https://user-images.githubusercontent.com/7036209/170687171-5da729b5-2012-4381-88b9-e8e4d7d97108.png)

