### PR TITLE
したらば掲示板のパースに失敗する問題を修正

### DIFF
--- a/src/main/readBBS/ReadSitaraba.ts
+++ b/src/main/readBBS/ReadSitaraba.ts
@@ -146,7 +146,7 @@ const parseNewResponse = (res: string) => {
   const result: ReturnType<typeof purseResponse>[] = [];
 
   // 新着レスを改行ごとにSplitする
-  const resArray = res.split(/\r\n|\r|\n/);
+  const resArray = res.split(/\n/);
   // 1行ごとにパースする
   resArray.forEach((value) => {
     // パースメソッド呼び出し


### PR DESCRIPTION
レスの内容にCR(\x0D)が含まれている場合に、パースに失敗する問題を修正します。

[一レス毎の改行コードは、LF(\x0A)のみと定められている](http://blog.livedoor.jp/bbsnews/archives/50283526.html)ため他の改行コードは不要で
CR+LFでなくCRのみで書き込みされたレスが含まれている場合に、したらばはCRを残したまま
書き込みが反映されるため、パースに失敗します。

JaneやSikiといったブラウザではunacastがパースに失敗するスレでも正常に読み込めるため、これで問題はないと思います。