### PR TITLE
/api/ws の broadcast リーク修正 + バースト時の taskScheduler 待機短縮

### DIFF
--- a/src/main/startServer.ts
+++ b/src/main/startServer.ts
@@ -42,8 +42,14 @@ let threadIntervalEvent = false;
 /** キュー処理実行するか */
 let isExecuteQue = false;
 
-/** 接続中の全WebSocket */
+/** 接続中の全WebSocket (express-ws の共有プール。/ws と /api/ws の両方が含まれる) */
 let aWss: ReturnType<expressWs.Instance['getWss']>;
+
+/**
+ * 配信画面 (OBS ブラウザソース等) 向けの /ws に接続している WebSocket だけを保持する集合。
+ * sendDom 等のブロードキャストはここに対してだけ行い、外部入力用 /api/ws の接続には流さない。
+ */
+const displayClients: Set<import('ws').WebSocket> = new Set();
 
 let serverId = 0;
 
@@ -481,15 +487,17 @@ ipcMain.on(electronEvent.START_SERVER, async (event: any, config: (typeof global
   /**
    * 配信画面 (OBS ブラウザソース等) との WebSocket。
    *
-   * - サーバ側 → ブラウザ: sendDom() 内で aWss.clients.forEach(c => c.send(...)) で
+   * - サーバ側 → ブラウザ: sendDom() 内で displayClients.forEach(c => c.send(...)) で
    *   コメント DOM を全 client にブロードキャストする (出力方向のメイン経路)。
    * - ブラウザ側 → サーバ: 接続維持のため定期 ping を送ってくる (public/js/readThread.js)。
    *   pong を返すだけで、データは受け取らない。
    *
-   * したがって、外部ツールからの受信は別パス /api/ws で行う (registerExternalApiRoutes)。
-   * 役割を混ぜないため /ws はこの ping/pong + ブロードキャストの用途に留めること。
+   * 受信用 /api/ws の接続まで巻き込まないよう、broadcast 対象はこのハンドラで管理する
+   * displayClients 集合に限定する。aWss.clients は両 path を含むため使わない。
+   * 外部ツールからの受信は別パス /api/ws で行う (registerExternalApiRoutes)。
    */
   app.ws('/ws', (ws) => {
+    displayClients.add(ws);
     ws.on('message', (message) => {
       log.debug('Received: ' + message.toString());
       if (message.toString() === 'ping') {
@@ -498,6 +506,7 @@ ipcMain.on(electronEvent.START_SERVER, async (event: any, config: (typeof global
     });
 
     ws.on('close', () => {
+      displayClients.delete(ws);
       log.debug('I lost a client');
     });
   });
@@ -704,6 +713,7 @@ ipcMain.on(electronEvent.STOP_SERVER, (event) => {
   log.debug('[startServer] server stop');
   server.close();
   aWss.close();
+  displayClients.clear();
   app = null as any;
   event.returnValue = 'stop';
 
@@ -1138,13 +1148,13 @@ export const sendDom = async (messageList: UserComment[]) => {
     // 配信画面 (WebSocket でブラウザソースへ送る分) は sourceFilter.broadcast でフィルタする。
     // chat ウィンドウ / SE / 読み上げは newList のまま (フィルタしない)。
     const broadcastList = filterByAxis('broadcast', newList);
-    if (broadcastList.length > 0 && aWss) {
+    if (broadcastList.length > 0 && displayClients.size > 0) {
       const domStr = broadcastList.map((message) => createDom(message, 'server', message.isAA)).join('\n');
       const socketObject: CommentSocketMessage = {
         type: 'add',
         message: domStr,
       };
-      aWss.clients.forEach((client) => {
+      displayClients.forEach((client) => {
         client.send(JSON.stringify(socketObject));
       });
     }
@@ -1233,7 +1243,7 @@ const resetInitMessage = () => {
       type: 'reset',
       message: globalThis.config.initMessage,
     };
-    aWss.clients.forEach((client) => {
+    displayClients.forEach((client) => {
       client.send(JSON.stringify(resetObj));
     });
   }


### PR DESCRIPTION
外部入力 WebSocket `/api/ws` 周りで発見した 2 件の問題を修正します。

## 1. `/api/ws` 接続が配信画面向け broadcast を受け取ってしまう

### 原因

`express-ws` の `expressInstance.getWss()` が返す `aWss.clients` は **同一サーバ内の全パスの WebSocket 接続を含む**ため、`sendDom()` 内の

```ts
aWss.clients.forEach((client) => client.send(JSON.stringify(socketObject)));
```

が `/ws` (配信画面ブラウザソース向け出力) だけでなく `/api/ws` (外部ツール受信用) の接続にもブロードキャストを送出していました。

外部ツール側からするとコメント投入の応答として `{"ok":true}` だけが返ってくる想定だったので、`{"type":"add", ...}` の DOM ブロードキャストまで届いて JSON パース失敗や echo 問題を起こす可能性がありました。

### 修正

- `/ws` に接続した WebSocket だけを `displayClients: Set<WebSocket>` で別途追跡。`app.ws('/ws', ...)` ハンドラの add / close で出入りを管理
- `sendDom` / `resetInitMessage` のブロードキャストを `aWss.clients.forEach` → `displayClients.forEach` に切り替え
- `STOP_SERVER` で `displayClients.clear()` も呼んで状態を残さない

### 受入テスト

`/ws` と `/api/ws` の 2 経路を同時接続し、`/api/ws` からコメント投入したとき:

| 経路 | 期待 | 結果 |
|---|---|---|
| `/ws` (配信画面側) | add メッセージを受信 | ✅ PASS |
| `/api/ws` (外部入力側) | add メッセージを **受信しない** | ✅ PASS |
| `/api/ws` (外部入力側) | `{"ok":true}` 応答を受信 | ✅ PASS |

---

## 2. キューが詰まった時に taskScheduler の待機が長すぎる

### 原因

`taskScheduler` は毎サイクル `sleep(100)` で待つ実装で、`commentProcessType=1` (1つずつ) モードの実効スループット上限が **約 10 件/秒** に抑えられていました。配信サイトからの自然なペース (秒間 1〜2 件) では問題ないものの、外部入力 (REST/WS) でバースト投入された場合に表示が著しく遅延します。

実測: SE / 読み上げを全部 OFF にしても、500 msg/sec × 10秒 = 5000 件を投入したキューの消化に **約 9 分** かかる。

### 修正

`nextSchedulerDelayMs()` を新設し、以下を **すべて満たす時のみ** sleep を 100ms → 10ms に短縮:

- `dispType: 0` (チャット風) … SpeechCast 風の `minDisplayTime` 拘束が無い
- `playSe` / `playSeStt` が両方 false … 着信音待ちが無い
- `typeYomiko` / `typeYomikoStt` が両方 `'none'` … 読み上げ待ちが無い
- キュー長 > 20 … 通常運用のペースは維持

いずれかに当てはまらない場合は従来通り 100ms を維持。SE/読み上げと同期した既存の見栄えは変えません。

### 計測

| | 修正前 | 修正後 |
|---|---|---|
| 5000件投入時の drain rate | ~9 件/秒 | **~63 件/秒 (約 7 倍速)** |
| 5000件 drain 所要時間 | 約 9 分 | **約 80 秒** |
| `/api/ws` 応答レイテンシ (キュー push まで) | avg 0.01ms | 変化なし |

通常運用 (キュー長 <= 20) では従来通り 100ms 周期で動くため、音声・タイミングと同期した既存の挙動は維持されます。

---

## 影響範囲

- `src/main/startServer.ts` のみ
- 既存の配信サイト連携 (`getRes` / niconama / twicas / jpnkn / youtube-chat) は変更なし
- レンダラー側は変更なし
- `npm run lint` / `npx tsc --noEmit` / `npm run build` 通過