### PR TITLE
キューが詰まった時のみ taskScheduler の待機を短縮

### DIFF
--- a/src/main/startServer.ts
+++ b/src/main/startServer.ts
@@ -914,9 +914,32 @@ const taskScheduler = async (exeId: number) => {
   }
 
   if (isExecuteQue && exeId === serverId) {
-    await sleep(100);
+    await sleep(nextSchedulerDelayMs());
     taskScheduler(exeId);
   }
+};
+
+/**
+ * taskScheduler の次回起動までの待ち時間 (ms) を決定する。
+ *
+ * 通常は 100ms で、配信サイトの自然なペース (秒間 1-2 件程度) を想定した間隔。
+ * ただし以下の「待たせる理由が一つも無い」状況に限り、キュー消化を優先するため短縮する:
+ *   - dispType が 0 (チャット風)   ... SpeechCast 風の minDisplayTime 拘束が無い
+ *   - SE 全 OFF (playSe / playSeStt)
+ *   - 読み上げ全 OFF (typeYomiko / typeYomikoStt がいずれも 'none')
+ *   - キュー長 > BURST_THRESHOLD ... 単発・小さいバーストは通常通り表示
+ */
+const TASK_NORMAL_DELAY_MS = 100;
+const TASK_FAST_DELAY_MS = 10;
+const BURST_THRESHOLD = 10;
+const nextSchedulerDelayMs = (): number => {
+  const queueLen = globalThis.electron?.commentQueueList?.length ?? 0;
+  if (queueLen <= BURST_THRESHOLD) return TASK_NORMAL_DELAY_MS;
+  const cfg = globalThis.config;
+  if (!cfg) return TASK_NORMAL_DELAY_MS;
+  const noAudio = !cfg.playSe && !cfg.playSeStt && cfg.typeYomiko === 'none' && cfg.typeYomikoStt === 'none';
+  const isChatStyle = cfg.dispType === 0;
+  return isChatStyle && noAudio ? TASK_FAST_DELAY_MS : TASK_NORMAL_DELAY_MS;
 };
 
 /**


### PR DESCRIPTION
## 背景

PR #52 で外部入力 WebSocket `/api/ws` を実用化したが、そのテスト中にキュー消化速度の問題を確認した。

`taskScheduler` は毎サイクル `sleep(100)` で待つ実装で、`commentProcessType=1` (1つずつ) モードでは実効スループットが **約 10 件/秒** に抑えられている。配信サイトからの自然なペース (秒間 1〜2 件) では問題ないが、外部入力でバースト投入された場合に表示が著しく遅延する。

実測 (修正前): SE / 読み上げを全部 OFF にしても、500 msg/sec × 10秒 = 5000 件投入したキューの消化に **約 9 分** かかった。

## 修正

`nextSchedulerDelayMs()` を新設し、以下を **すべて満たす時のみ** sleep を 100ms → 10ms に短縮:

- `dispType: 0` (チャット風) … SpeechCast 風の `minDisplayTime` 拘束が無い
- `playSe` / `playSeStt` が両方 false … 着信音待ちが無い
- `typeYomiko` / `typeYomikoStt` が両方 `'none'` … 読み上げ待ちが無い
- キュー長 > 20 … 通常運用のペースは維持

いずれかに当てはまらない場合は従来通り 100ms を維持。SE / 読み上げ / minDisplayTime と同期した既存の見栄えは変えない。

## 計測

500 msg/sec × 10s = 5000 件投入時:

| | 修正前 | 修正後 |
|---|---|---|
| キュー drain rate | ~9 件/秒 | **~63 件/秒** (約 7 倍速) |
| 5000 件の消化所要時間 | 約 9 分 | **約 80 秒** |
| `/api/ws` の応答レイテンシ (キュー push まで) | avg 0.01ms | 変化なし |
| 通常運用 (キュー長 ≤ 20) の挙動 | — | **完全に維持** |

## 影響範囲

- `src/main/startServer.ts` のみ
- 既存の配信サイト連携 (`getRes` / niconama / twicas / jpnkn / youtube-chat) は変更なし
- レンダラー側は変更なし
- `npm run lint` / `npx tsc --noEmit` / `npm run build` 通過