### PR TITLE
resources/style-server.css によるカスタム CSS 機能を復活

### DIFF
--- a/src/html/chat.html
+++ b/src/html/chat.html
@@ -7,6 +7,14 @@
   <title>unacast - chat</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
   <link rel="stylesheet" href="/css/style-server.css" />
+  <!--
+    ユーザカスタム CSS。packaged app の resources/style-server.css を読みに行く。
+    chat.html は dist/renderer/src/html/ に出力されるため、ここから resources/ までは 5 階層上。
+    asar 版ではこの相対パスが asar の外へ出て物理 resources/ を指す。
+    ファイルが存在しなくても 404 で黙って無視されるので副作用なし。
+    詳細: documents/見た目のカスタム.md
+  -->
+  <link rel="stylesheet" href="../../../../../style-server.css" />
   <script type="module" src="../renderer/chat.ts"></script>
   <script>
     /** URLをクリックした時の動作 */

--- a/src/html/translate.html
+++ b/src/html/translate.html
@@ -6,6 +6,14 @@
     <title>unacast - translate</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <link rel="stylesheet" href="/css/style-server.css" />
+    <!--
+      ユーザカスタム CSS。packaged app の resources/style-server.css を読みに行く。
+      translate.html は dist/renderer/src/html/ に出力されるため、ここから resources/ までは 5 階層上。
+      asar 版ではこの相対パスが asar の外へ出て物理 resources/ を指す。
+      ファイルが存在しなくても 404 で黙って無視されるので副作用なし。
+      詳細: documents/見た目のカスタム.md
+    -->
+    <link rel="stylesheet" href="../../../../../style-server.css" />
     <script type="module" src="../renderer/translate.ts"></script>
     <script>
       const urlopen = (url) => {


### PR DESCRIPTION
## 概要

`documents/見た目のカスタム.md` に記載されている、**packaged app の `resources/` フォルダ直下に `style-server.css` を置けば chat / translate ウィンドウの見た目を上書きできる** 機能が、React 化以降効かなくなっていたので復活させます。

## 原因

1. **旧 HTML にあった `<link>` を React 化時に落としていた**
   旧 `chat.html` / `translate.html` には `<link rel="stylesheet" href="../../../style-server.css" />` の行があったが、React 移行で HTML を書き直した際に消えていた。

2. **Vite 化で HTML 出力位置の階層が深くなり、5 階層上に変わった**
   - 旧 webpack 版: chat.html は `app/src/html/chat.html` に配置 → `../../../style-server.css` (3 ups) で `resources/` に到達
   - 新 electron-vite 版: chat.html は `app/dist/renderer/src/html/chat.html` (= `app.asar/dist/renderer/src/html/chat.html`) に配置 → **5 ups で `resources/` に到達**

## 修正

`chat.html` / `translate.html` に以下を追加。bundled default CSS の後ろに置くので、ユーザの override が cascade 優先になる。

```html
<link rel="stylesheet" href="../../../../../style-server.css" />
```

- asar 版でも unpack 版でもこの相対パスは物理 `resources/style-server.css` に解決される (asar の外への遡及は Electron が透過的に処理する)
- ファイルが存在しない場合は 404 で黙って無視されるので、カスタム CSS を置かないユーザにも副作用なし
- 5 階層 `..` のマジックナンバー意図がパッと見で分からないので、HTML 内コメントで階層構造の解説と `documents/見た目のカスタム.md` へのリンクを残した

## 影響範囲

- `src/html/chat.html`
- `src/html/translate.html`
- TS / JS / 設定ファイル変更なし。`npm run lint` / `npm run build` 通過
- カスタム CSS を置いていないユーザ: 挙動変化なし
- カスタム CSS を置いていたユーザ: 旧来通り反映される