### PR TITLE
build: Chromium locale と koffi prebuild を刈り取って artifact 30-40MB 削減

### DIFF
--- a/electron-package.js
+++ b/electron-package.js
@@ -40,6 +40,67 @@ const ignore = [
 
 const expectedOutDir = path.resolve(`unacast-${PLATFORM}-x64`);
 
+// 残す Chromium ロケール。.pak は Chromium 自身の UI 文字列 (右クリックメニュー
+// やエラーページ等) の翻訳であり、ページ本文 (= コメント) の表示には影響しない。
+// ja / en があれば日本語環境 + 英語 fallback で実用上問題ないので、その他の
+// 56 言語分 (~30MB) を packaging 時に削除する。
+const KEEP_LOCALE_PREFIXES = ['ja', 'en'];
+
+// koffi は build/koffi/<platform>_<arch>/ にプラットフォーム毎の prebuilt が
+// 全部入っている (18 個 × ~1.5MB = ~27MB)。実行ターゲット以外は不要なので、
+// 対象 platform_arch 以外の prebuild ディレクトリを削除する。
+const trimChromiumLocales = (buildPath, electronVersion, platform, arch, callback) => {
+  // buildPath = <stagingPath>/resources/app  →  locales は <stagingPath>/locales
+  const localesDir = path.join(buildPath, '..', '..', 'locales');
+  try {
+    if (!fs.existsSync(localesDir)) {
+      return callback();
+    }
+    let removed = 0;
+    let kept = 0;
+    for (const name of fs.readdirSync(localesDir)) {
+      const lang = name.replace(/\.pak$/, '');
+      const keep = KEEP_LOCALE_PREFIXES.some((p) => lang === p || lang.startsWith(`${p}-`));
+      if (!keep) {
+        fs.unlinkSync(path.join(localesDir, name));
+        removed += 1;
+      } else {
+        kept += 1;
+      }
+    }
+    console.log(`[electron-package] trimmed Chromium locales: kept=${kept} removed=${removed}`);
+    callback();
+  } catch (err) {
+    callback(err);
+  }
+};
+
+const trimKoffiPrebuilds = (buildPath, electronVersion, platform, arch, callback) => {
+  const koffiDir = path.join(buildPath, 'node_modules', 'koffi', 'build', 'koffi');
+  try {
+    if (!fs.existsSync(koffiDir)) {
+      return callback();
+    }
+    const keepDir = `${platform}_${arch}`;
+    let removed = 0;
+    let kept = 0;
+    for (const name of fs.readdirSync(koffiDir)) {
+      const full = path.join(koffiDir, name);
+      if (!fs.statSync(full).isDirectory()) continue;
+      if (name === keepDir) {
+        kept += 1;
+      } else {
+        fs.rmSync(full, { recursive: true, force: true });
+        removed += 1;
+      }
+    }
+    console.log(`[electron-package] trimmed koffi prebuilds: kept=${kept} (${keepDir}) removed=${removed}`);
+    callback();
+  } catch (err) {
+    callback(err);
+  }
+};
+
 (async () => {
   try {
     const appPaths = await packager({
@@ -52,6 +113,7 @@ const expectedOutDir = path.resolve(`unacast-${PLATFORM}-x64`);
       icon: 'icon.ico',
       asar: ASAR,
       ignore,
+      afterCopy: [trimKoffiPrebuilds, trimChromiumLocales],
     });
     if (!appPaths || appPaths.length === 0) {
       console.error('[electron-package] packager returned empty appPaths');


### PR DESCRIPTION
## 背景

Windows artifact が現在 143MB あり、配布物として大きすぎる。内訳を見ると Electron 本体 + ロケール pak が支配的だったので、削れる箇所を `electron-packager` の `afterCopy` フックで自動的に刈り取る。

## 何を刈るか

### 1. Chromium ロケール `.pak` (58 言語 → ja / en のみ)

`node_modules/electron/dist/locales/` に 58 個 (~42MB) 入っているが、これは **Chromium 自身の UI 文字列の翻訳** (右クリックメニュー / エラーページ / 認証ダイアログ / スペルチェッカ警告 など) であり、**ページ本文 (= コメント) の表示には無関係**。コメントが多言語で来ても、表示は OS のフォント + Chromium の文字レンダリングが担当するので `.pak` 削減の影響は受けない。

影響範囲は実質「中国語 Windows ユーザが画像で右クリックしたとき『画像を保存』が中国語じゃなく英語になる」レベル。

→ `ja*` / `en*` だけ残し、他言語を削除。

### 2. koffi の platform-specific prebuild

`node_modules/koffi/build/koffi/` に `win32_x64` / `darwin_x64` / `darwin_arm64` / `linux_x64` / `freebsd_x64` ... など **18 プラットフォーム分の prebuilt が全部** 入っている (各 ~1.5MB、合計 ~27MB)。実行ターゲットの 1 個だけあれば良いので、対象 `${platform}_${arch}` 以外を削除。

`afterCopy` フックは `@electron/packager` から `platform` / `arch` を引数で受け取れるので、

- Windows ビルド (`win32` `x64`) → `win32_x64` のみ残す
- macOS x64 ビルド (`darwin` `x64`) → `darwin_x64` のみ残す
- macOS Apple Silicon ビルド (`darwin` `arm64`) → `darwin_arm64` のみ残す

と自動分岐する。

## なぜ `afterCopy` か

`@electron/packager` のフック実行順序:

```
copyTemplate (app source を resources/app/ へコピー)
  └─ afterCopy hooks ←★ ここで動く
prune (devDeps 削除)
  └─ afterPrune hooks
asarApp (resources/app/ を app.asar に固める)
```

- koffi (`<buildPath>/node_modules/koffi/...`) は `afterCopy` で削れば **asar に取り込まれる前に縮む** ので圧縮効率が良い
- Chromium locales (`<stagingPath>/locales/*.pak`) は asar 外なので、`afterCopy` で直接 unlink すれば即縮む

## 期待効果

| 項目 | 削減量 |
|---|---|
| Chromium locales | ~30-35MB (圧縮後 ~15-20MB) |
| koffi prebuilds | ~25MB (圧縮後 ~10-15MB) |
| 合計 (artifact zip ベース) | **30-40MB** |

現在 143MB → 100-110MB 程度になる見込み。

## Test plan

- [ ] CI で `Build (buildwin)` のログに以下が出ること:
  - `[electron-package] trimmed koffi prebuilds: kept=1 (win32_x64) removed=17`
  - `[electron-package] trimmed Chromium locales: kept=N removed=M` (N+M=58)
- [ ] artifact upload サイズが 143MB → 100-110MB 程度に縮むこと
- [ ] アプリ起動後、コメント表示 (日英中韓など多言語) が正常であること
- [ ] アプリ起動後、koffi を使う機能 (画面ドラッグ系) が正常動作すること

https://claude.ai/code/session_01G4kdNnonCA8wXX4CxArRif

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4kdNnonCA8wXX4CxArRif)_