### PR TITLE
スレッドブラウザを追加 (一覧・プレビュー・スレ移動)

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
           chat: resolve(__dirname, 'src/html/chat.html'),
           translate: resolve(__dirname, 'src/html/translate.html'),
           imagePreview: resolve(__dirname, 'src/html/imagePreview.html'),
+          threadBrowser: resolve(__dirname, 'src/html/threadBrowser.html'),
         },
       },
     },

--- a/src/html/threadBrowser.html
+++ b/src/html/threadBrowser.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>unacast - スレッド一覧</title>
+  <style>
+    html, body { margin: 0; padding: 0; height: 100%; }
+    #root { height: 100%; }
+  </style>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="../renderer/threadBrowser.tsx"></script>
+</body>
+
+</html>

--- a/src/main/const.ts
+++ b/src/main/const.ts
@@ -54,4 +54,15 @@ export const electronEvent = {
   AZURE_STT_START: 'azure-stt-start',
   AZURE_STT_STOP: 'azure-stt-stop',
   AZURE_STT_EVENT: 'azure-stt-event',
+
+  /** スレッドブラウザを開く (renderer → main) */
+  OPEN_THREAD_BROWSER: 'open-thread-browser',
+  /** スレッドブラウザ: 初期化 (板情報の解決) */
+  THREAD_BROWSER_INIT: 'thread-browser-init',
+  /** スレッドブラウザ: スレ一覧取得 */
+  THREAD_BROWSER_LIST: 'thread-browser-list',
+  /** スレッドブラウザ: スレ内容プレビュー */
+  THREAD_BROWSER_PREVIEW: 'thread-browser-preview',
+  /** スレッドブラウザ: コメント読み込みスレッドの切り替え */
+  THREAD_BROWSER_APPLY: 'thread-browser-apply',
 };

--- a/src/main/const.ts
+++ b/src/main/const.ts
@@ -65,4 +65,9 @@ export const electronEvent = {
   THREAD_BROWSER_PREVIEW: 'thread-browser-preview',
   /** スレッドブラウザ: コメント読み込みスレッドの切り替え */
   THREAD_BROWSER_APPLY: 'thread-browser-apply',
+  /**
+   * スレッドブラウザ: main 側 config 未初期化時 (サーバー起動・適用前) のスレURL変更通知。
+   * main → メイン設定ウィンドウ renderer。renderer 側で config.url を更新・永続化する。
+   */
+  THREAD_BROWSER_URL_SELECTED: 'thread-browser-url-selected',
 };

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8,6 +8,7 @@ import windowStateKeeper from 'electron-window-state';
 import ElectronStore from 'electron-store';
 // サーバー起動モジュール (IPC ハンドラ等の副作用登録目的)
 import './startServer';
+import { initThreadBrowser } from './threadBrowser';
 remote.initialize();
 
 /**
@@ -15,7 +16,7 @@ remote.initialize();
  *  - electron-vite dev 中: process.env.ELECTRON_RENDERER_URL に dev サーバの URL が入る
  *  - production: dist/main/index.js から見た dist/renderer/src/html/<name>.html を file:// で読む
  */
-const resolveRendererUrl = (htmlName: 'index' | 'chat' | 'translate' | 'imagePreview') => {
+const resolveRendererUrl = (htmlName: 'index' | 'chat' | 'translate' | 'imagePreview' | 'threadBrowser') => {
   const devUrl = process.env.ELECTRON_RENDERER_URL;
   if (devUrl) {
     return `${devUrl}/src/html/${htmlName}.html`;
@@ -250,6 +251,7 @@ if (!app.requestSingleInstanceLock()) {
     createChatWindow();
     createTranslateWindow();
     createImagePreviewWindow();
+    initThreadBrowser(() => resolveRendererUrl('threadBrowser'));
 
     applyTaskbarState();
   });

--- a/src/main/threadBrowser.ts
+++ b/src/main/threadBrowser.ts
@@ -20,9 +20,6 @@ import { unescapeHtml } from './util';
 
 export type ThreadBrowserMode = 'bbs' | 'jpnkn';
 
-/** プレビューで末尾から表示するレス数 */
-const PREVIEW_TAIL_COUNT = 10;
-
 let browserWindow: electron.BrowserWindow | null = null;
 
 /** threadBrowser.html の URL を解決する関数。main.ts の初期化時に渡される */
@@ -34,14 +31,18 @@ let resolvePageUrl: () => string = () => '';
  */
 let requestedSource: string | null = null;
 
-/** モードから板URL解決の元になる値を返す。設定が無い場合は null */
+/**
+ * モードから板URL解決の元になる値を返す。設定が無い場合は null。
+ * globalThis.config はサーバー起動・適用・テストのいずれかを行うまで main 側では
+ * undefined のため (renderer からしか渡されない)、optional chaining で参照する。
+ */
 const resolveBoardUrl = (mode: ThreadBrowserMode): string | null => {
   if (mode === 'jpnkn') {
-    const boardId = requestedSource || globalThis.config.jpnknFastBoardId;
+    const boardId = requestedSource || globalThis.config?.jpnknFastBoardId;
     if (!boardId) return null;
     return `https://bbs.jpnkn.com/${boardId}/`;
   }
-  const threadUrl = requestedSource || globalThis.config.url;
+  const threadUrl = requestedSource || globalThis.config?.url;
   if (!threadUrl) return null;
   return threadUrl;
 };
@@ -122,7 +123,7 @@ export const initThreadBrowser = (resolveUrl: () => string) => {
         mode,
         boardUrl: info.boardUrl,
         boardName: info.boardName,
-        currentThreadUrl: globalThis.config.url ?? '',
+        currentThreadUrl: globalThis.config?.url ?? '',
       };
     } catch (e) {
       log.error(e);
@@ -142,24 +143,22 @@ export const initThreadBrowser = (resolveUrl: () => string) => {
   });
 
   /**
-   * スレ内容のプレビュー。1レス目 + 末尾数レスをプレーンテキストで返す。
+   * スレ内容のプレビュー。全レスをプレーンテキストで返す (テンプレ確認等のため省略しない)。
+   * resNum は「この番号より後」の意味なので、レス1を含む全件は 0 を指定する。
    * コメント取得のポーリングが使う共有インスタンス (getRes.ts のシングルトン) の
    * 取得位置キャッシュを壊さないよう、毎回新しいインスタンスで読む。
    */
   ipcMain.handle(electronEvent.THREAD_BROWSER_PREVIEW, async (_event, threadUrl: string) => {
     try {
       const reader = threadUrl.includes('jbbs.shitaraba.net') ? new ReadSitaraba() : new Read5ch();
-      const comments = await reader.read(threadUrl, 1);
-      const slim = (c: UserComment): ThreadPreviewItem => ({
+      const comments = await reader.read(threadUrl, 0);
+      const items: ThreadPreviewItem[] = comments.map((c) => ({
         number: c.number ?? '',
         name: toPlainText(c.name ?? ''),
         date: c.date ?? '',
         text: toPlainText(c.text ?? ''),
-      });
-      const total = comments.length;
-      const head = comments.slice(0, 1).map(slim);
-      const tail = comments.slice(1).slice(-PREVIEW_TAIL_COUNT).map(slim);
-      return { ok: true, total, head, tail };
+      }));
+      return { ok: true, total: items.length, comments: items };
     } catch (e) {
       log.error(e);
       return { ok: false, error: 'スレッドの内容を取得できませんでした。' };
@@ -174,9 +173,15 @@ export const initThreadBrowser = (resolveUrl: () => string) => {
   ipcMain.handle(electronEvent.THREAD_BROWSER_APPLY, async (_event, threadUrl: string) => {
     try {
       log.info(`[apply] ${threadUrl}`);
-      globalThis.config.url = threadUrl;
-      globalThis.electron.threadNumber = 0;
-      globalThis.electron.mainWindow.webContents.send(electronEvent.SAVE_CONFIG, globalThis.config);
+      if (globalThis.config) {
+        globalThis.config.url = threadUrl;
+        globalThis.electron.threadNumber = 0;
+        globalThis.electron.mainWindow.webContents.send(electronEvent.SAVE_CONFIG, globalThis.config);
+      } else {
+        // main 側の config はサーバー起動・適用・テストのいずれかまで未初期化。
+        // その場合は renderer に URL だけ通知し、renderer 側で config.url を更新・永続化する
+        globalThis.electron.mainWindow.webContents.send(electronEvent.THREAD_BROWSER_URL_SELECTED, threadUrl);
+      }
 
       // サーバー起動中ならシステムコメントで移動を通知する
       if (globalThis.electron.commentQueueList) {

--- a/src/main/threadBrowser.ts
+++ b/src/main/threadBrowser.ts
@@ -1,0 +1,197 @@
+/**
+ * スレッドブラウザ (スレ一覧・プレビュー・スレ移動) のウィンドウと IPC ハンドラ。
+ *
+ * - bbs モード: config.url のスレが属する板を開く。「このスレッドに移動」でコメント
+ *   読み込みの threadUrl を置き換えられる (自動スレ移動 checkAutoMoveThread と同じ機構)。
+ * - jpnkn モード: config.jpnknFastBoardId の板を開く。MQTT で板全体を受信する方式で
+ *   「特定スレを読む」概念がないため、一覧とプレビューのみ (移動は renderer 側で非表示)。
+ */
+import electron, { ipcMain } from 'electron';
+import * as remote from '@electron/remote/main';
+import windowStateKeeper from 'electron-window-state';
+import electronlog from 'electron-log';
+const log = electronlog.scope('threadBrowser');
+
+import { electronEvent } from './const';
+import { getThreadList, threadUrlToBoardInfo } from './getRes';
+import ReadSitaraba from './readBBS/ReadSitaraba';
+import Read5ch from './readBBS/Read5ch';
+import { unescapeHtml } from './util';
+
+export type ThreadBrowserMode = 'bbs' | 'jpnkn';
+
+/** プレビューで末尾から表示するレス数 */
+const PREVIEW_TAIL_COUNT = 10;
+
+let browserWindow: electron.BrowserWindow | null = null;
+
+/** threadBrowser.html の URL を解決する関数。main.ts の初期化時に渡される */
+let resolvePageUrl: () => string = () => '';
+
+/**
+ * 「掲示板を開く」時に設定画面から渡された入力値 (bbs: スレURL / jpnkn: 板ID)。
+ * 適用前の編集中の値でも開けるように、globalThis.config より優先する。
+ */
+let requestedSource: string | null = null;
+
+/** モードから板URL解決の元になる値を返す。設定が無い場合は null */
+const resolveBoardUrl = (mode: ThreadBrowserMode): string | null => {
+  if (mode === 'jpnkn') {
+    const boardId = requestedSource || globalThis.config.jpnknFastBoardId;
+    if (!boardId) return null;
+    return `https://bbs.jpnkn.com/${boardId}/`;
+  }
+  const threadUrl = requestedSource || globalThis.config.url;
+  if (!threadUrl) return null;
+  return threadUrl;
+};
+
+const openWindow = (mode: ThreadBrowserMode) => {
+  if (browserWindow && !browserWindow.isDestroyed()) {
+    // 既に開いている場合はモードを合わせて前面に出す
+    browserWindow.loadURL(`${resolvePageUrl()}?mode=${mode}`);
+    browserWindow.show();
+    browserWindow.focus();
+    return;
+  }
+
+  const windowState = windowStateKeeper({
+    defaultWidth: 960,
+    defaultHeight: 700,
+    file: 'threadBrowser.json',
+  });
+
+  browserWindow = new electron.BrowserWindow({
+    x: windowState.x,
+    y: windowState.y,
+    width: windowState.width,
+    height: windowState.height,
+    useContentSize: true,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+  remote.enable(browserWindow.webContents);
+  windowState.manage(browserWindow);
+
+  browserWindow.setTitle('unacast - スレッド一覧');
+  browserWindow.setMenu(null);
+  browserWindow.loadURL(`${resolvePageUrl()}?mode=${mode}`);
+  browserWindow.on('closed', () => {
+    browserWindow = null;
+  });
+  // browserWindow.webContents.openDevTools();
+};
+
+/** レス本文/名前の HTML を、プレビュー表示用のプレーンテキストへ変換する */
+const toPlainText = (html: string): string => {
+  return unescapeHtml(
+    html
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/<[^>]+>/g, '')
+      .trim(),
+  );
+};
+
+export type ThreadPreviewItem = { number: string; name: string; date: string; text: string };
+
+/** IPC ハンドラとウィンドウ生成を登録する。main.ts の起動処理から一度だけ呼ぶ */
+export const initThreadBrowser = (resolveUrl: () => string) => {
+  resolvePageUrl = resolveUrl;
+
+  ipcMain.on(electronEvent.OPEN_THREAD_BROWSER, (_event, payload: { mode: ThreadBrowserMode; source?: string }) => {
+    log.info(`[open] mode=${payload.mode}`);
+    requestedSource = payload.source || null;
+    openWindow(payload.mode);
+  });
+
+  /** 板情報の解決。板名・板URL・現在読み込み中のスレURLを返す */
+  ipcMain.handle(electronEvent.THREAD_BROWSER_INIT, async (_event, mode: ThreadBrowserMode) => {
+    try {
+      const source = resolveBoardUrl(mode);
+      if (!source) {
+        return { ok: false, error: mode === 'jpnkn' ? 'jpnkn の板IDが設定されていません。' : '掲示板URLが設定されていません。' };
+      }
+      const info = await threadUrlToBoardInfo(source);
+      if (info.status !== 'ok') {
+        return { ok: false, error: `板情報を取得できませんでした (${source})` };
+      }
+      return {
+        ok: true,
+        mode,
+        boardUrl: info.boardUrl,
+        boardName: info.boardName,
+        currentThreadUrl: globalThis.config.url ?? '',
+      };
+    } catch (e) {
+      log.error(e);
+      return { ok: false, error: '板情報の取得中にエラーが発生しました。' };
+    }
+  });
+
+  /** スレ一覧の取得 */
+  ipcMain.handle(electronEvent.THREAD_BROWSER_LIST, async (_event, boardUrl: string) => {
+    try {
+      const threads = await getThreadList(boardUrl);
+      return { ok: true, threads };
+    } catch (e) {
+      log.error(e);
+      return { ok: false, error: 'スレッド一覧を取得できませんでした。' };
+    }
+  });
+
+  /**
+   * スレ内容のプレビュー。1レス目 + 末尾数レスをプレーンテキストで返す。
+   * コメント取得のポーリングが使う共有インスタンス (getRes.ts のシングルトン) の
+   * 取得位置キャッシュを壊さないよう、毎回新しいインスタンスで読む。
+   */
+  ipcMain.handle(electronEvent.THREAD_BROWSER_PREVIEW, async (_event, threadUrl: string) => {
+    try {
+      const reader = threadUrl.includes('jbbs.shitaraba.net') ? new ReadSitaraba() : new Read5ch();
+      const comments = await reader.read(threadUrl, 1);
+      const slim = (c: UserComment): ThreadPreviewItem => ({
+        number: c.number ?? '',
+        name: toPlainText(c.name ?? ''),
+        date: c.date ?? '',
+        text: toPlainText(c.text ?? ''),
+      });
+      const total = comments.length;
+      const head = comments.slice(0, 1).map(slim);
+      const tail = comments.slice(1).slice(-PREVIEW_TAIL_COUNT).map(slim);
+      return { ok: true, total, head, tail };
+    } catch (e) {
+      log.error(e);
+      return { ok: false, error: 'スレッドの内容を取得できませんでした。' };
+    }
+  });
+
+  /**
+   * コメント読み込みのスレッドURLを置き換える。
+   * 自動スレ移動 (checkAutoMoveThread) と同じ機構: config.url を書き換えて
+   * threadNumber をリセットし、renderer へ SAVE_CONFIG で通知して永続化させる。
+   */
+  ipcMain.handle(electronEvent.THREAD_BROWSER_APPLY, async (_event, threadUrl: string) => {
+    try {
+      log.info(`[apply] ${threadUrl}`);
+      globalThis.config.url = threadUrl;
+      globalThis.electron.threadNumber = 0;
+      globalThis.electron.mainWindow.webContents.send(electronEvent.SAVE_CONFIG, globalThis.config);
+
+      // サーバー起動中ならシステムコメントで移動を通知する
+      if (globalThis.electron.commentQueueList) {
+        globalThis.electron.commentQueueList.push({
+          name: 'unacastより',
+          imgUrl: '/img/unacast.png',
+          text: 'スレッドを移動しました',
+          type: 'comment',
+          from: 'system',
+        });
+      }
+      return { ok: true };
+    } catch (e) {
+      log.error(e);
+      return { ok: false, error: 'スレッドの切り替えに失敗しました。' };
+    }
+  });
+};

--- a/src/renderer/app/ipc.ts
+++ b/src/renderer/app/ipc.ts
@@ -155,10 +155,17 @@ export const registerIpcSubscribers = () => {
     }
   });
 
-  // main プロセス側で config が書き換えられた時の通知 (現状は自動スレ移動による url 変更のみ)。
+  // main プロセス側で config が書き換えられた時の通知 (自動スレ移動・スレッドブラウザによる url 変更)。
   // フォーム編集中の値を消さないよう、未編集のフィールドだけマージする。
   ipcRenderer.on(electronEvent.SAVE_CONFIG, (_event: any, arg: AppConfig) => {
     useAppStore.getState().mergeFromServer(arg);
+    useAppStore.getState().persist();
+  });
+
+  // スレッドブラウザでのスレ移動 (main 側 config 未初期化時のフォールバック)。
+  // url フィールドだけ更新して永続化する。適用ボタンで main へ反映される。
+  ipcRenderer.on(electronEvent.THREAD_BROWSER_URL_SELECTED, (_event: any, url: string) => {
+    useAppStore.getState().setConfig('url', url);
     useAppStore.getState().persist();
   });
 

--- a/src/renderer/app/ipc.ts
+++ b/src/renderer/app/ipc.ts
@@ -186,3 +186,12 @@ export const sendCommentTest = (config: AppConfig) => {
 export const sendLoadVoicevox = (voicevox: AppConfig['voicevox']) => {
   ipcRenderer.send(electronEvent.LOAD_VOICEVOX, voicevox);
 };
+
+/**
+ * スレッドブラウザを開く。
+ * source には設定画面で入力中の値 (bbs: スレURL / jpnkn: 板ID) を渡す。
+ * 適用前でも入力中の掲示板を開けるようにするため。
+ */
+export const sendOpenThreadBrowser = (mode: 'bbs' | 'jpnkn', source: string) => {
+  ipcRenderer.send(electronEvent.OPEN_THREAD_BROWSER, { mode, source });
+};

--- a/src/renderer/app/sections/Sources.tsx
+++ b/src/renderer/app/sections/Sources.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { Box, TextField, Typography } from '@mui/material';
+import { Box, Button, TextField, Typography } from '@mui/material';
 import { useAppStore } from '../store';
+import { sendOpenThreadBrowser } from '../ipc';
 import { SectionPanel, LabeledInput, Caption, SourceFilterToggle, StatusDot, getStatusColor } from './common';
 
 /**
@@ -44,6 +45,11 @@ export const Sources: React.FC = () => {
         />
         <SourceFilterToggle source="bbs" axis="broadcast" />
         <StatusLine label="status" value={status.bbs} configured={!!config.url} />
+        <Box sx={{ mt: 0.5 }}>
+          <Button size="small" variant="outlined" disabled={!config.url} onClick={() => sendOpenThreadBrowser('bbs', config.url)}>
+            掲示板を開く
+          </Button>
+        </Box>
       </Box>
 
       {/* Jpnkn Fast */}
@@ -56,6 +62,11 @@ export const Sources: React.FC = () => {
         </LabeledInput>
         <SourceFilterToggle source="jpnkn" axis="broadcast" />
         <StatusLine label="status" value={status.jpnknFast} configured={!!config.jpnknFastBoardId} />
+        <Box sx={{ mt: 0.5 }}>
+          <Button size="small" variant="outlined" disabled={!config.jpnknFastBoardId} onClick={() => sendOpenThreadBrowser('jpnkn', config.jpnknFastBoardId)}>
+            掲示板を開く
+          </Button>
+        </Box>
       </Box>
 
       {/* YouTube */}

--- a/src/renderer/threadBrowser.tsx
+++ b/src/renderer/threadBrowser.tsx
@@ -22,7 +22,6 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  Divider,
   IconButton,
   List,
   ListItemButton,
@@ -42,7 +41,7 @@ const ipcRenderer = electron.ipcRenderer;
 type ThreadItem = { url: string; name: string; resNum: number };
 type InitResult = { ok: boolean; error?: string; mode?: ThreadBrowserMode; boardUrl?: string; boardName?: string; currentThreadUrl?: string };
 type ListResult = { ok: boolean; error?: string; threads?: ThreadItem[] };
-type PreviewResult = { ok: boolean; error?: string; total?: number; head?: ThreadPreviewItem[]; tail?: ThreadPreviewItem[] };
+type PreviewResult = { ok: boolean; error?: string; total?: number; comments?: ThreadPreviewItem[] };
 type ApplyResult = { ok: boolean; error?: string };
 
 const mode: ThreadBrowserMode = new URLSearchParams(location.search).get('mode') === 'jpnkn' ? 'jpnkn' : 'bbs';
@@ -124,7 +123,6 @@ const ThreadBrowserApp: React.FC = () => {
   };
 
   const selectedThread = threads.find((t) => t.url === selectedUrl);
-  const omitted = preview?.ok ? Math.max(0, (preview.total ?? 0) - 1 - (preview.tail?.length ?? 0)) : 0;
 
   if (initError) {
     return (
@@ -206,23 +204,7 @@ const ThreadBrowserApp: React.FC = () => {
             </Box>
           )}
           {preview && !preview.ok && <Alert severity="error">{preview.error}</Alert>}
-          {preview?.ok && (
-            <>
-              {preview.head?.map((item) => (
-                <PreviewComment key={`h-${item.number}`} item={item} />
-              ))}
-              {omitted > 0 && (
-                <Divider sx={{ my: 1 }}>
-                  <Typography variant="caption" color="text.secondary">
-                    … {omitted} レス省略 …
-                  </Typography>
-                </Divider>
-              )}
-              {preview.tail?.map((item) => (
-                <PreviewComment key={`t-${item.number}`} item={item} />
-              ))}
-            </>
-          )}
+          {preview?.ok && preview.comments?.map((item) => <PreviewComment key={item.number} item={item} />)}
         </Box>
       </Box>
 

--- a/src/renderer/threadBrowser.tsx
+++ b/src/renderer/threadBrowser.tsx
@@ -1,0 +1,274 @@
+/**
+ * スレッドブラウザウィンドウ。
+ *
+ * 左にスレッド一覧、右に選択スレのプレビュー (1レス目 + 末尾10レス) を表示する。
+ * bbs モードでは「このスレッドに移動」でコメント読み込みのスレURLを置き換えられる。
+ * jpnkn モードは板全体を MQTT で受信する方式で特定スレを読む概念がないため、
+ * 一覧とプレビューのみ (移動ボタンは表示しない)。
+ *
+ * モードは URL クエリ `?mode=bbs|jpnkn` で受け取る (main/threadBrowser.ts が付与)。
+ */
+import * as React from 'react';
+import { createRoot } from 'react-dom/client';
+import electron from 'electron';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  CssBaseline,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  List,
+  ListItemButton,
+  ListItemText,
+  Snackbar,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { ThemeProvider } from '@mui/material/styles';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import { compactTheme } from './app/theme';
+import { electronEvent } from '../main/const';
+import type { ThreadBrowserMode, ThreadPreviewItem } from '../main/threadBrowser';
+
+const ipcRenderer = electron.ipcRenderer;
+
+type ThreadItem = { url: string; name: string; resNum: number };
+type InitResult = { ok: boolean; error?: string; mode?: ThreadBrowserMode; boardUrl?: string; boardName?: string; currentThreadUrl?: string };
+type ListResult = { ok: boolean; error?: string; threads?: ThreadItem[] };
+type PreviewResult = { ok: boolean; error?: string; total?: number; head?: ThreadPreviewItem[]; tail?: ThreadPreviewItem[] };
+type ApplyResult = { ok: boolean; error?: string };
+
+const mode: ThreadBrowserMode = new URLSearchParams(location.search).get('mode') === 'jpnkn' ? 'jpnkn' : 'bbs';
+
+/** プレビューの1レス表示 */
+const PreviewComment: React.FC<{ item: ThreadPreviewItem }> = ({ item }) => (
+  <Box sx={{ mb: 1 }}>
+    <Typography variant="caption" color="text.secondary">
+      {item.number} {item.name} {item.date}
+    </Typography>
+    <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+      {item.text}
+    </Typography>
+  </Box>
+);
+
+const ThreadBrowserApp: React.FC = () => {
+  const [boardName, setBoardName] = React.useState('');
+  const [boardUrl, setBoardUrl] = React.useState('');
+  const [currentThreadUrl, setCurrentThreadUrl] = React.useState('');
+  const [initError, setInitError] = React.useState('');
+
+  const [threads, setThreads] = React.useState<ThreadItem[]>([]);
+  const [listLoading, setListLoading] = React.useState(false);
+  const [listError, setListError] = React.useState('');
+
+  const [selectedUrl, setSelectedUrl] = React.useState('');
+  const [preview, setPreview] = React.useState<PreviewResult | null>(null);
+  const [previewLoading, setPreviewLoading] = React.useState(false);
+
+  const [confirmTarget, setConfirmTarget] = React.useState<ThreadItem | null>(null);
+  const [snackbar, setSnackbar] = React.useState('');
+
+  const loadList = React.useCallback(async (url: string) => {
+    setListLoading(true);
+    setListError('');
+    const res: ListResult = await ipcRenderer.invoke(electronEvent.THREAD_BROWSER_LIST, url);
+    setListLoading(false);
+    if (!res.ok) {
+      setListError(res.error ?? 'スレッド一覧を取得できませんでした。');
+      return;
+    }
+    setThreads(res.threads ?? []);
+  }, []);
+
+  // 初期化: 板情報を解決してスレ一覧を読む
+  React.useEffect(() => {
+    (async () => {
+      const res: InitResult = await ipcRenderer.invoke(electronEvent.THREAD_BROWSER_INIT, mode);
+      if (!res.ok) {
+        setInitError(res.error ?? '初期化に失敗しました。');
+        return;
+      }
+      setBoardName(res.boardName ?? '');
+      setBoardUrl(res.boardUrl ?? '');
+      setCurrentThreadUrl(res.currentThreadUrl ?? '');
+      await loadList(res.boardUrl ?? '');
+    })();
+  }, [loadList]);
+
+  const openPreview = async (thread: ThreadItem) => {
+    setSelectedUrl(thread.url);
+    setPreviewLoading(true);
+    setPreview(null);
+    const res: PreviewResult = await ipcRenderer.invoke(electronEvent.THREAD_BROWSER_PREVIEW, thread.url);
+    setPreviewLoading(false);
+    setPreview(res);
+  };
+
+  const applyThread = async (thread: ThreadItem) => {
+    setConfirmTarget(null);
+    const res: ApplyResult = await ipcRenderer.invoke(electronEvent.THREAD_BROWSER_APPLY, thread.url);
+    if (!res.ok) {
+      setSnackbar(res.error ?? 'スレッドの切り替えに失敗しました。');
+      return;
+    }
+    setCurrentThreadUrl(thread.url);
+    setSnackbar(`コメント読み込みスレッドを「${thread.name}」に切り替えました`);
+  };
+
+  const selectedThread = threads.find((t) => t.url === selectedUrl);
+  const omitted = preview?.ok ? Math.max(0, (preview.total ?? 0) - 1 - (preview.tail?.length ?? 0)) : 0;
+
+  if (initError) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Alert severity="error">{initError}</Alert>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+      {/* ヘッダー: 板名 + 更新 */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 1.5, py: 1, borderBottom: '1px solid #ddd' }}>
+        <Typography variant="h6" sx={{ flexGrow: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {boardName || '読み込み中…'}
+        </Typography>
+        {mode === 'jpnkn' && <Chip size="small" label="jpnkn (一覧・プレビューのみ)" />}
+        <Tooltip title="スレッド一覧を更新">
+          <span>
+            <IconButton size="small" onClick={() => loadList(boardUrl)} disabled={listLoading || !boardUrl} aria-label="更新">
+              <RefreshIcon />
+            </IconButton>
+          </span>
+        </Tooltip>
+      </Box>
+
+      <Box sx={{ display: 'flex', flex: 1, minHeight: 0 }}>
+        {/* スレッド一覧 */}
+        <Box sx={{ width: '42%', minWidth: 280, borderRight: '1px solid #ddd', overflowY: 'auto' }}>
+          {listLoading && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
+              <CircularProgress size={22} />
+            </Box>
+          )}
+          {listError && (
+            <Box sx={{ p: 1.5 }}>
+              <Alert
+                severity="error"
+                action={
+                  <Button size="small" onClick={() => loadList(boardUrl)}>
+                    再試行
+                  </Button>
+                }
+              >
+                {listError}
+              </Alert>
+            </Box>
+          )}
+          <List dense disablePadding>
+            {threads.map((thread) => {
+              const isCurrent = mode === 'bbs' && thread.url === currentThreadUrl;
+              return (
+                <ListItemButton key={thread.url} selected={thread.url === selectedUrl} onClick={() => openPreview(thread)} sx={{ py: 0.25 }}>
+                  <ListItemText
+                    primary={
+                      <>
+                        {isCurrent && <Chip size="small" color="primary" label="読込中" sx={{ mr: 0.5, height: 16, fontSize: 10 }} />}
+                        {thread.name} ({thread.resNum})
+                      </>
+                    }
+                    primaryTypographyProps={{ variant: 'body2', sx: { wordBreak: 'break-word' } }}
+                  />
+                </ListItemButton>
+              );
+            })}
+          </List>
+        </Box>
+
+        {/* プレビュー */}
+        <Box sx={{ flex: 1, overflowY: 'auto', p: 1.5 }}>
+          {!selectedUrl && (
+            <Typography variant="body2" color="text.secondary">
+              左の一覧からスレッドを選択すると内容をプレビューします。
+            </Typography>
+          )}
+          {previewLoading && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
+              <CircularProgress size={22} />
+            </Box>
+          )}
+          {preview && !preview.ok && <Alert severity="error">{preview.error}</Alert>}
+          {preview?.ok && (
+            <>
+              {preview.head?.map((item) => (
+                <PreviewComment key={`h-${item.number}`} item={item} />
+              ))}
+              {omitted > 0 && (
+                <Divider sx={{ my: 1 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    … {omitted} レス省略 …
+                  </Typography>
+                </Divider>
+              )}
+              {preview.tail?.map((item) => (
+                <PreviewComment key={`t-${item.number}`} item={item} />
+              ))}
+            </>
+          )}
+        </Box>
+      </Box>
+
+      {/* フッター: スレ移動 (bbs のみ) */}
+      {mode === 'bbs' && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 1.5, py: 1, borderTop: '1px solid #ddd' }}>
+          <Typography variant="caption" color="text.secondary" sx={{ flexGrow: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {selectedThread ? selectedThread.url : 'スレッドを選択してください'}
+          </Typography>
+          <Button variant="contained" size="small" disabled={!selectedThread || selectedThread.url === currentThreadUrl} onClick={() => setConfirmTarget(selectedThread ?? null)}>
+            このスレッドに移動
+          </Button>
+        </Box>
+      )}
+
+      {/* 移動確認ダイアログ */}
+      <Dialog open={!!confirmTarget} onClose={() => setConfirmTarget(null)}>
+        <DialogTitle>スレッドの移動</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2">コメント読み込みのスレッドを以下に切り替えます。よろしいですか?</Typography>
+          <Typography variant="body2" sx={{ mt: 1, fontWeight: 'bold', wordBreak: 'break-word' }}>
+            {confirmTarget?.name} ({confirmTarget?.resNum})
+          </Typography>
+          <Typography variant="caption" color="text.secondary" sx={{ wordBreak: 'break-all' }}>
+            {confirmTarget?.url}
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmTarget(null)}>キャンセル</Button>
+          <Button variant="contained" onClick={() => confirmTarget && applyThread(confirmTarget)}>
+            OK
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar open={!!snackbar} autoHideDuration={4000} onClose={() => setSnackbar('')} message={snackbar} />
+    </Box>
+  );
+};
+
+const container = document.getElementById('root');
+if (container) {
+  createRoot(container).render(
+    <ThemeProvider theme={compactTheme}>
+      <CssBaseline />
+      <ThreadBrowserApp />
+    </ThemeProvider>,
+  );
+}


### PR DESCRIPTION
## 概要

- unacast上から掲示板のスレッドを確認・移動できるようにするスレッドブラウザを追加。

| 機能 | bbs (5ch互換 / したらば) | jpnkn |
|---|---|---|
| スレッド一覧 | ○ | ○ |
| プレビュー | ○ | ○ |
| スレッドに移動 | ○ | × (MQTTで板全体を受信する方式のため対象外。ボタン非表示) |
