### PR TITLE
スレッドブラウザにスレ立て機能を追加

### DIFF
--- a/src/main/const.ts
+++ b/src/main/const.ts
@@ -70,4 +70,8 @@ export const electronEvent = {
    * main → メイン設定ウィンドウ renderer。renderer 側で config.url を更新・永続化する。
    */
   THREAD_BROWSER_URL_SELECTED: 'thread-browser-url-selected',
+  /** スレッドブラウザ: スレ立てフォームへのコピー元 (現在のスレの1レス目) 取得 */
+  THREAD_BROWSER_CREATE_SOURCE: 'thread-browser-create-source',
+  /** スレッドブラウザ: スレ立て実行 */
+  THREAD_BROWSER_CREATE: 'thread-browser-create',
 };

--- a/src/main/readBBS/createThread.ts
+++ b/src/main/readBBS/createThread.ts
@@ -1,0 +1,162 @@
+/**
+ * スレ立て (新規スレッド作成) の POST 実装。
+ *
+ * 既存のレス投稿 (Read5ch.postRes / ReadSitaraba.postRes) と同じエンコード機構を使い、
+ * スレ立て用のパラメータ (key の代わりに subject) で write cgi を叩く。
+ *
+ * 注意: 掲示板の write cgi は失敗でも HTTP 200 でエラーHTMLを返すため、ここでの
+ * 判定はベストエフォート。成功の最終確認は呼び出し元 (threadBrowser.ts) が
+ * subject.txt を再取得して新スレの出現を確認することで行う。
+ */
+import axios, { AxiosRequestConfig } from 'axios';
+import https from 'https';
+import iconv from 'iconv-lite';
+import encoding from 'encoding-japanese';
+import electronlog from 'electron-log';
+const log = electronlog.scope('createThread');
+
+const instance = axios.create({
+  httpsAgent: new https.Agent({
+    rejectUnauthorized: false,
+  }),
+});
+
+export type CreateThreadParams = {
+  title: string;
+  name: string;
+  mail: string;
+  body: string;
+};
+
+export type CreateThreadPostResult = {
+  /** 応答本文から見た判定。'unknown' は成功とも失敗とも断定できない (subject.txt での確認に委ねる) */
+  status: 'ok' | 'error' | 'unknown';
+  /** status='error' のとき、応答から抽出したエラーメッセージ */
+  error?: string;
+};
+
+/** 文字列を指定文字コードへ変換して URL エンコードする (postRes と同じ方式) */
+const toEncodedParam = (value: string, to: 'SJIS' | 'EUCJP'): string => {
+  const unicodeArray: number[] = [];
+  for (let i = 0; i < value.length; i++) {
+    unicodeArray.push(value.charCodeAt(i));
+  }
+  const converted = encoding.convert(unicodeArray, { to, from: 'UNICODE' });
+  return encoding.urlEncode(converted as number[]);
+};
+
+/** 本文の改行を掲示板が期待する \r\n に揃える */
+const normalizeBody = (body: string) => body.replace(/\r?\n/g, '\r\n');
+
+/** 応答HTMLからエラーメッセージらしき部分を抽出する */
+const extractErrorMessage = (html: string): string => {
+  const bold = html.match(/<b>([^<]+)<\/b>/i)?.[1];
+  const title = html.match(/<title>([^<]+)<\/title>/i)?.[1];
+  const message = (bold || title || '').replace(/\s+/g, ' ').trim();
+  return message || '掲示板からエラーが返されました';
+};
+
+/** 応答HTMLの判定 */
+const judgeResponseHtml = (html: string): CreateThreadPostResult => {
+  if (/書きこみました|書き込みました/.test(html)) return { status: 'ok' };
+  if (/ERROR|ＥＲＲＯＲ|エラー|Samba|SAMBA/i.test(html)) return { status: 'error', error: extractErrorMessage(html) };
+  return { status: 'unknown' };
+};
+
+/** 確認画面 (クッキー確認) かどうか */
+const isConfirmPage = (html: string): boolean => /書き込み確認|書きこみ確認|クッキー|cookie/i.test(html);
+
+/** set-cookie ヘッダから Cookie ヘッダ値を組み立てる */
+const buildCookieHeader = (setCookies: string[] | undefined): string => {
+  if (!setCookies || setCookies.length === 0) return '';
+  return setCookies.map((c) => c.split(';')[0]).join('; ');
+};
+
+const post = async (url: string, payload: string, charset: string, headers: Record<string, string>) => {
+  const options: AxiosRequestConfig = {
+    url,
+    method: 'POST',
+    data: payload,
+    timeout: 10 * 1000,
+    responseType: 'arraybuffer',
+    headers: {
+      Accept: '*/*',
+      'Content-Type': 'application/x-www-form-urlencoded',
+      ...headers,
+    },
+    // 302 (成功時にリダイレクトを返す板がある) も許容する
+    validateStatus: (status: number) => status >= 200 && status < 400,
+    maxRedirects: 0,
+  };
+  const response = await instance(options);
+  const html = iconv.decode(Buffer.from(response.data as any), charset);
+  return { response, html };
+};
+
+/**
+ * 5ch互換板 (jpnkn 含む) のスレ立て。
+ * POST {hostname}test/bbs.cgi に key の代わりに subject を付けると新規スレッド作成になる。
+ * 初回書き込みの確認画面 (クッキー確認) が返ってきた場合は、付与されたクッキーを
+ * 持って同じ内容を 1 回だけ再送する。
+ *
+ * @param hostname 例 https://bbs.jpnkn.com/
+ * @param boardId 例 pasta04
+ */
+export const createThread5ch = async (hostname: string, boardId: string, p: CreateThreadParams): Promise<CreateThreadPostResult> => {
+  const payload = [
+    `subject=${toEncodedParam(p.title, 'SJIS')}`,
+    `FROM=${toEncodedParam(p.name, 'SJIS')}`,
+    `mail=${toEncodedParam(p.mail, 'SJIS')}`,
+    `MESSAGE=${toEncodedParam(normalizeBody(p.body), 'SJIS')}`,
+    `bbs=${boardId}`,
+    `time=${Math.floor(Date.now() / 1000)}`,
+    `submit=${toEncodedParam('新規スレッド作成', 'SJIS')}`,
+  ].join('&');
+  const url = `${hostname}test/bbs.cgi`;
+  const baseHeaders = { Referer: `${hostname}${boardId}/` };
+
+  log.info(`[createThread5ch] ${url} bbs=${boardId}`);
+  const first = await post(url, payload, 'Shift_JIS', baseHeaders);
+  if (isConfirmPage(first.html)) {
+    // クッキーを持って1回だけ再送
+    log.info('[createThread5ch] confirm page returned. retrying with cookies');
+    const cookie = buildCookieHeader(first.response.headers['set-cookie']);
+    const second = await post(url, payload, 'Shift_JIS', { ...baseHeaders, ...(cookie ? { Cookie: cookie } : {}) });
+    return judgeResponseHtml(second.html);
+  }
+  return judgeResponseHtml(first.html);
+};
+
+/**
+ * したらばのスレ立て。
+ * POST {hostname}bbs/write.cgi/{dir}/{bbs}/ (スレ番号なし) + subject で新規スレッド作成。
+ *
+ * @param hostname 例 https://jbbs.shitaraba.net/
+ * @param dir 例 game
+ * @param bbs 例 51638
+ */
+export const createThreadShitaraba = async (hostname: string, dir: string, bbs: string, p: CreateThreadParams): Promise<CreateThreadPostResult> => {
+  const payload = [
+    `dir=${dir}`,
+    `bbs=${bbs}`,
+    `time=${Math.floor(Date.now() / 1000)}`,
+    `subject=${toEncodedParam(p.title, 'EUCJP')}`,
+    `NAME=${toEncodedParam(p.name, 'EUCJP')}`,
+    `MAIL=${toEncodedParam(p.mail, 'EUCJP')}`,
+    `MESSAGE=${toEncodedParam(normalizeBody(p.body), 'EUCJP')}`,
+    `submit=${toEncodedParam('新規書き込み', 'EUCJP')}`,
+  ].join('&');
+  const url = `${hostname}bbs/write.cgi/${dir}/${bbs}/`;
+
+  log.info(`[createThreadShitaraba] ${url}`);
+  const { response, html } = await post(url, payload, 'EUC-JP', { Referer: `${hostname}${dir}/${bbs}/` });
+  // したらばは成功時に302を返すことがある
+  if (response.status >= 300 && response.status < 400) return { status: 'ok' };
+  if (isConfirmPage(html)) {
+    const cookie = buildCookieHeader(response.headers['set-cookie']);
+    const second = await post(url, payload, 'EUC-JP', { Referer: `${hostname}${dir}/${bbs}/`, ...(cookie ? { Cookie: cookie } : {}) });
+    if (second.response.status >= 300 && second.response.status < 400) return { status: 'ok' };
+    return judgeResponseHtml(second.html);
+  }
+  return judgeResponseHtml(html);
+};

--- a/src/main/readBBS/createThread.ts
+++ b/src/main/readBBS/createThread.ts
@@ -72,6 +72,13 @@ const buildCookieHeader = (setCookies: string[] | undefined): string => {
   return setCookies.map((c) => c.split(';')[0]).join('; ');
 };
 
+/**
+ * 書き込み系リクエストで名乗る User-Agent。
+ * したらば等は UA 無し (axios 既定) の write.cgi POST を 403 で弾くことがあるため、
+ * 掲示板ツールの慣習である Monazilla 形式を名乗る。
+ */
+const WRITE_USER_AGENT = 'Monazilla/1.00 (unacast)';
+
 const post = async (url: string, payload: string, charset: string, headers: Record<string, string>) => {
   const options: AxiosRequestConfig = {
     url,
@@ -82,15 +89,24 @@ const post = async (url: string, payload: string, charset: string, headers: Reco
     headers: {
       Accept: '*/*',
       'Content-Type': 'application/x-www-form-urlencoded',
+      'User-Agent': WRITE_USER_AGENT,
       ...headers,
     },
-    // 302 (成功時にリダイレクトを返す板がある) も許容する
-    validateStatus: (status: number) => status >= 200 && status < 400,
+    // エラーHTML (4xx/5xx) も本文を読んで判定したいので、HTTPステータスでは例外にしない
+    validateStatus: () => true,
     maxRedirects: 0,
   };
   const response = await instance(options);
   const html = iconv.decode(Buffer.from(response.data as any), charset);
+  log.info(`[post] ${url} -> ${response.status} body=${html.replace(/\s+/g, ' ').slice(0, 200)}`);
   return { response, html };
+};
+
+/** HTTP ステータスも加味した応答判定 */
+const judgeResponse = (status: number, html: string): CreateThreadPostResult => {
+  if (status >= 300 && status < 400) return { status: 'ok' }; // 成功時にリダイレクトを返す板がある
+  if (status >= 400) return { status: 'error', error: `HTTP ${status}: ${extractErrorMessage(html)}` };
+  return judgeResponseHtml(html);
 };
 
 /**
@@ -122,41 +138,43 @@ export const createThread5ch = async (hostname: string, boardId: string, p: Crea
     log.info('[createThread5ch] confirm page returned. retrying with cookies');
     const cookie = buildCookieHeader(first.response.headers['set-cookie']);
     const second = await post(url, payload, 'Shift_JIS', { ...baseHeaders, ...(cookie ? { Cookie: cookie } : {}) });
-    return judgeResponseHtml(second.html);
+    return judgeResponse(second.response.status, second.html);
   }
-  return judgeResponseHtml(first.html);
+  return judgeResponse(first.response.status, first.html);
 };
 
 /**
  * したらばのスレ立て。
- * POST {hostname}bbs/write.cgi/{dir}/{bbs}/ (スレ番号なし) + subject で新規スレッド作成。
+ * POST {hostname}bbs/write.cgi/{dir}/{bbs}/ (スレ番号なし) + SUBJECT で新規スレッド作成。
+ * したらばの write.cgi のパラメータ名は大文字 (DIR/BBS/TIME/NAME/MAIL/MESSAGE/SUBJECT)。
+ * また http だと 403 になることがあるため https に正規化する。
  *
  * @param hostname 例 https://jbbs.shitaraba.net/
  * @param dir 例 game
  * @param bbs 例 51638
  */
 export const createThreadShitaraba = async (hostname: string, dir: string, bbs: string, p: CreateThreadParams): Promise<CreateThreadPostResult> => {
+  const secureHost = hostname.replace(/^http:/, 'https:');
   const payload = [
-    `dir=${dir}`,
-    `bbs=${bbs}`,
-    `time=${Math.floor(Date.now() / 1000)}`,
-    `subject=${toEncodedParam(p.title, 'EUCJP')}`,
+    `DIR=${dir}`,
+    `BBS=${bbs}`,
+    `TIME=${Math.floor(Date.now() / 1000)}`,
+    `SUBJECT=${toEncodedParam(p.title, 'EUCJP')}`,
     `NAME=${toEncodedParam(p.name, 'EUCJP')}`,
     `MAIL=${toEncodedParam(p.mail, 'EUCJP')}`,
     `MESSAGE=${toEncodedParam(normalizeBody(p.body), 'EUCJP')}`,
-    `submit=${toEncodedParam('新規書き込み', 'EUCJP')}`,
+    `submit=${toEncodedParam('新規スレッド作成', 'EUCJP')}`,
   ].join('&');
-  const url = `${hostname}bbs/write.cgi/${dir}/${bbs}/`;
+  const url = `${secureHost}bbs/write.cgi/${dir}/${bbs}/`;
+  const baseHeaders = { Referer: `${secureHost}${dir}/${bbs}/` };
 
   log.info(`[createThreadShitaraba] ${url}`);
-  const { response, html } = await post(url, payload, 'EUC-JP', { Referer: `${hostname}${dir}/${bbs}/` });
-  // したらばは成功時に302を返すことがある
-  if (response.status >= 300 && response.status < 400) return { status: 'ok' };
-  if (isConfirmPage(html)) {
-    const cookie = buildCookieHeader(response.headers['set-cookie']);
-    const second = await post(url, payload, 'EUC-JP', { Referer: `${hostname}${dir}/${bbs}/`, ...(cookie ? { Cookie: cookie } : {}) });
-    if (second.response.status >= 300 && second.response.status < 400) return { status: 'ok' };
-    return judgeResponseHtml(second.html);
+  const first = await post(url, payload, 'EUC-JP', baseHeaders);
+  if (isConfirmPage(first.html)) {
+    log.info('[createThreadShitaraba] confirm page returned. retrying with cookies');
+    const cookie = buildCookieHeader(first.response.headers['set-cookie']);
+    const second = await post(url, payload, 'EUC-JP', { ...baseHeaders, ...(cookie ? { Cookie: cookie } : {}) });
+    return judgeResponse(second.response.status, second.html);
   }
-  return judgeResponseHtml(html);
+  return judgeResponse(first.response.status, first.html);
 };

--- a/src/main/startServer.ts
+++ b/src/main/startServer.ts
@@ -7,7 +7,7 @@ import { ChatClient } from 'dank-twitch-irc';
 import { LiveChat } from './youtube-chat';
 import { ipcMain } from 'electron';
 import expressWs from 'express-ws';
-import { readWavFiles, sleep, escapeHtml, unescapeHtml, judgeAaMessage, isNihongo, convertUrltoImgTagSrc } from './util';
+import { readWavFiles, sleep, escapeHtml, unescapeHtml, decodeNumericCharRefs, removeEmoji, judgeAaMessage, isNihongo, convertUrltoImgTagSrc } from './util';
 import { filterByAxis } from './sourceFilter';
 import { judgeNgWord } from './ngWord';
 import { registerExternalApiRoutes } from './externalApi/routes';
@@ -1267,6 +1267,8 @@ export const sendDom = async (messageList: UserComment[]) => {
           config.yomikoDictionary.forEach((entry) => {
             text = text.replace(new RegExp(entry.pattern, 'gim'), entry.pronunciation);
           });
+          // 数値文字参照 (&#10084; 等) を復号したうえで、Unicode 絵文字は読み上げに渡さない
+          text = removeEmoji(decodeNumericCharRefs(text));
           text = unescapeHtml(text);
 
           if (globalThis.config.yomikoReplaceNewline) {

--- a/src/main/threadBrowser.ts
+++ b/src/main/threadBrowser.ts
@@ -288,7 +288,8 @@ export const initThreadBrowser = (resolveUrl: () => string) => {
       return { ok: false, error: 'スレッドの作成を確認できませんでした。時間をおいて一覧を更新してください。' };
     } catch (e) {
       log.error(e);
-      return { ok: false, error: 'スレッド作成中にエラーが発生しました。' };
+      const message = e instanceof Error ? e.message : String(e);
+      return { ok: false, error: `スレッド作成中にエラーが発生しました (${message})` };
     }
   });
 };

--- a/src/main/threadBrowser.ts
+++ b/src/main/threadBrowser.ts
@@ -16,7 +16,8 @@ import { electronEvent } from './const';
 import { getThreadList, threadUrlToBoardInfo } from './getRes';
 import ReadSitaraba from './readBBS/ReadSitaraba';
 import Read5ch from './readBBS/Read5ch';
-import { unescapeHtml } from './util';
+import { createThread5ch, createThreadShitaraba, CreateThreadPostResult } from './readBBS/createThread';
+import { unescapeHtml, sleep } from './util';
 
 export type ThreadBrowserMode = 'bbs' | 'jpnkn';
 
@@ -96,6 +97,12 @@ const toPlainText = (html: string): string => {
 };
 
 export type ThreadPreviewItem = { number: string; name: string; date: string; text: string };
+
+/** スレ立てフォームへコピーする元データ (スレタイ + 1レス目の名前/メール/本文) */
+export type ThreadCreateSource = { title: string; name: string; mail: string; body: string };
+
+/** スレURL末尾のスレキー (作成時刻由来の数値)。取れなければ 0 */
+const threadKey = (url: string): number => Number(url.match(/(\d+)\/?$/)?.[1] ?? 0);
 
 /** IPC ハンドラとウィンドウ生成を登録する。main.ts の起動処理から一度だけ呼ぶ */
 export const initThreadBrowser = (resolveUrl: () => string) => {
@@ -197,6 +204,91 @@ export const initThreadBrowser = (resolveUrl: () => string) => {
     } catch (e) {
       log.error(e);
       return { ok: false, error: 'スレッドの切り替えに失敗しました。' };
+    }
+  });
+
+  /**
+   * スレ立てフォームの「現在のスレッドからコピー」用データ取得。
+   * bbs: 現在コメント読み込み中のスレ / jpnkn: スレキー最大 (最も新しく立った) のスレ。
+   * スレタイと1レス目の名前・メール・本文を返す。
+   */
+  ipcMain.handle(electronEvent.THREAD_BROWSER_CREATE_SOURCE, async (_event, payload: { mode: ThreadBrowserMode; boardUrl: string }) => {
+    try {
+      let threadUrl: string | null;
+      if (payload.mode === 'jpnkn') {
+        const threads = await getThreadList(payload.boardUrl);
+        if (threads.length === 0) return { ok: false, error: 'コピー元にできるスレッドがありません。' };
+        threadUrl = threads.reduce((a, b) => (threadKey(b.url) > threadKey(a.url) ? b : a)).url;
+      } else {
+        threadUrl = requestedSource || globalThis.config?.url || null;
+        if (!threadUrl) return { ok: false, error: '現在読み込み中のスレッドがありません。' };
+      }
+
+      const reader = threadUrl.includes('jbbs.shitaraba.net') ? new ReadSitaraba() : new Read5ch();
+      const comments = await reader.read(threadUrl, 0);
+      if (comments.length === 0) return { ok: false, error: 'コピー元スレッドの内容を取得できませんでした。' };
+      const first = comments[0];
+      const source: ThreadCreateSource = {
+        title: toPlainText(first.threadTitle ?? ''),
+        name: toPlainText(first.name ?? ''),
+        mail: first.email ?? '',
+        body: toPlainText(first.text ?? ''),
+      };
+      return { ok: true, source };
+    } catch (e) {
+      log.error(e);
+      return { ok: false, error: 'コピー元スレッドの取得中にエラーが発生しました。' };
+    }
+  });
+
+  /**
+   * スレ立ての実行。
+   * write cgi は失敗でも HTTP 200 でエラーHTMLを返すため、応答本文の判定は
+   * ベストエフォートとし、成功の最終確認は subject.txt の再取得で
+   * 「実行前に無かった新スレが現れたか」を見る。
+   */
+  ipcMain.handle(electronEvent.THREAD_BROWSER_CREATE, async (_event, payload: { boardUrl: string; title: string; name: string; mail: string; body: string }) => {
+    try {
+      const { boardUrl, title, name, mail, body } = payload;
+      if (!title.trim() || !body.trim()) return { ok: false, error: 'タイトルと本文を入力してください。' };
+
+      // 実行前のスレ一覧 (新スレ出現の判定基準)
+      const before = new Set((await getThreadList(boardUrl).catch(() => [] as { url: string }[])).map((t) => t.url));
+
+      let postResult: CreateThreadPostResult;
+      if (boardUrl.includes('jbbs.shitaraba.net')) {
+        // 例: https://jbbs.shitaraba.net/game/51638/
+        const m = boardUrl.match(/^(https?:\/\/[^/]+\/)([^/]+)\/(\d+)\/?$/);
+        if (!m) return { ok: false, error: `したらばの板URLを解析できませんでした (${boardUrl})` };
+        postResult = await createThreadShitaraba(m[1], m[2], m[3], { title, name, mail, body });
+      } else {
+        // 例: https://bbs.jpnkn.com/pasta04/
+        const m = boardUrl.match(/^(https?:\/\/[^/]+\/)(.+?)\/?$/);
+        if (!m) return { ok: false, error: `板URLを解析できませんでした (${boardUrl})` };
+        postResult = await createThread5ch(m[1], m[2], { title, name, mail, body });
+      }
+      log.info(`[create] post status=${postResult.status} ${postResult.error ?? ''}`);
+
+      // subject.txt を再取得して新スレの出現を確認する (反映ラグを考慮して数回)
+      const normalize = (s: string) => s.replace(/\s+/g, '');
+      for (let attempt = 0; attempt < 3; attempt++) {
+        await sleep(1500);
+        const threads = await getThreadList(boardUrl).catch(() => [] as { url: string; name: string; resNum: number }[]);
+        const fresh = threads.filter((t) => !before.has(t.url));
+        // タイトル一致を優先し、一致が無くても新スレが1件だけなら自スレとみなす
+        const matched = fresh.find((t) => normalize(t.name).includes(normalize(title))) ?? (fresh.length === 1 ? fresh[0] : undefined);
+        if (matched) {
+          log.info(`[create] created: ${matched.url}`);
+          return { ok: true, newThreadUrl: matched.url };
+        }
+      }
+
+      // 新スレを確認できなかった。応答本文のエラーがあればそれを返す
+      if (postResult.status === 'error') return { ok: false, error: postResult.error };
+      return { ok: false, error: 'スレッドの作成を確認できませんでした。時間をおいて一覧を更新してください。' };
+    } catch (e) {
+      log.error(e);
+      return { ok: false, error: 'スレッド作成中にエラーが発生しました。' };
     }
   });
 };

--- a/src/main/threadBrowser.ts
+++ b/src/main/threadBrowser.ts
@@ -142,7 +142,15 @@ export const initThreadBrowser = (resolveUrl: () => string) => {
   ipcMain.handle(electronEvent.THREAD_BROWSER_LIST, async (_event, boardUrl: string) => {
     try {
       const threads = await getThreadList(boardUrl);
-      return { ok: true, threads };
+      // subject.txt は「最終更新スレ」が先頭にもう一度重複して現れる掲示板がある
+      // (したらば・jpnkn) ため、URL で重複を除く (先頭 = 更新順の位置を残す)
+      const seen = new Set<string>();
+      const unique = threads.filter((t) => {
+        if (seen.has(t.url)) return false;
+        seen.add(t.url);
+        return true;
+      });
+      return { ok: true, threads: unique };
     } catch (e) {
       log.error(e);
       return { ok: false, error: 'スレッド一覧を取得できませんでした。' };

--- a/src/main/threadBrowser.ts
+++ b/src/main/threadBrowser.ts
@@ -17,7 +17,7 @@ import { getThreadList, threadUrlToBoardInfo } from './getRes';
 import ReadSitaraba from './readBBS/ReadSitaraba';
 import Read5ch from './readBBS/Read5ch';
 import { createThread5ch, createThreadShitaraba, CreateThreadPostResult } from './readBBS/createThread';
-import { unescapeHtml, sleep } from './util';
+import { unescapeHtml, decodeNumericCharRefs, sleep } from './util';
 
 export type ThreadBrowserMode = 'bbs' | 'jpnkn';
 
@@ -86,13 +86,18 @@ const openWindow = (mode: ThreadBrowserMode) => {
   // browserWindow.webContents.openDevTools();
 };
 
-/** レス本文/名前の HTML を、プレビュー表示用のプレーンテキストへ変換する */
+/**
+ * レス本文/名前の HTML を、プレビュー表示用のプレーンテキストへ変換する。
+ * 絵文字等は数値文字参照 (&#10084; など) で入ってくるため復号して実際の文字にする。
+ */
 const toPlainText = (html: string): string => {
   return unescapeHtml(
-    html
-      .replace(/<br\s*\/?>/gi, '\n')
-      .replace(/<[^>]+>/g, '')
-      .trim(),
+    decodeNumericCharRefs(
+      html
+        .replace(/<br\s*\/?>/gi, '\n')
+        .replace(/<[^>]+>/g, '')
+        .trim(),
+    ),
   );
 };
 

--- a/src/main/threadBrowser.ts
+++ b/src/main/threadBrowser.ts
@@ -188,6 +188,9 @@ export const initThreadBrowser = (resolveUrl: () => string) => {
   ipcMain.handle(electronEvent.THREAD_BROWSER_APPLY, async (_event, threadUrl: string) => {
     try {
       log.info(`[apply] ${threadUrl}`);
+      // 「掲示板を開く」時に渡された入力値は config より優先されるため、
+      // 移動後の「現在のスレッドからコピー」等が旧スレを参照しないよう追従させる
+      requestedSource = threadUrl;
       if (globalThis.config) {
         globalThis.config.url = threadUrl;
         globalThis.electron.threadNumber = 0;

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -51,6 +51,39 @@ export const unescapeHtml = (str: string) => {
     .replace(/&amp;/g, '&');
 };
 
+const safeFromCodePoint = (codePoint: number, fallback: string): string => {
+  if (!Number.isInteger(codePoint) || codePoint <= 0 || codePoint > 0x10ffff) return fallback;
+  try {
+    return String.fromCodePoint(codePoint);
+  } catch {
+    return fallback;
+  }
+};
+
+/**
+ * 数値文字参照 (&#10084; / &#x2764; など) を実際の文字に復号する。
+ * Shift_JIS 等で表せない文字 (絵文字など) を掲示板がこの形式で dat に保存するため、
+ * プレーンテキスト化や読み上げの前に通す。HTML として描画する経路 (チャット窓・配信画面)
+ * はブラウザが復号するので不要。
+ * unescapeHtml より先に呼ぶこと (&amp;#123; のような「参照の字面」を壊さないため)。
+ */
+export const decodeNumericCharRefs = (str: string): string => {
+  return str
+    .replace(/&#x([0-9a-fA-F]+);/g, (match, hex) => safeFromCodePoint(parseInt(hex, 16), match))
+    .replace(/&#(\d+);/g, (match, dec) => safeFromCodePoint(Number(dec), match));
+};
+
+/**
+ * Unicode 絵文字にマッチするパターン。
+ * Extended_Pictographic (絵文字全般) + 異体字セレクタ + ZWJ + 肌色修飾 + 国旗 + キーキャップ結合。
+ * tsconfig の target (ES2015) では正規表現リテラルに \p{...} を書けないため RegExp で構築する。
+ */
+// eslint-disable-next-line no-misleading-character-class -- ZWJ・修飾子等の構成文字を個別に除去する意図のため問題ない
+const EMOJI_PATTERN = new RegExp('[\\p{Extended_Pictographic}\\u{FE0F}\\u{200D}\\u{1F3FB}-\\u{1F3FF}\\u{1F1E6}-\\u{1F1FF}\\u{20E3}]', 'gu');
+
+/** Unicode 絵文字を除去する (読み上げエンジンに絵文字を渡さないため) */
+export const removeEmoji = (text: string): string => text.replace(EMOJI_PATTERN, '');
+
 export const convertUrltoImgTagSrc = (imgUrl: string) => {
   // return imgUrl.match(/.+\.(jpg|png|gif)$/) ? imgUrl : `data:image/png;base64,${imgUrl}`;
   return imgUrl;

--- a/src/renderer/threadBrowser.tsx
+++ b/src/renderer/threadBrowser.tsx
@@ -27,6 +27,7 @@ import {
   ListItemButton,
   ListItemText,
   Snackbar,
+  TextField,
   Tooltip,
   Typography,
 } from '@mui/material';
@@ -34,7 +35,7 @@ import { ThemeProvider } from '@mui/material/styles';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import { compactTheme } from './app/theme';
 import { electronEvent } from '../main/const';
-import type { ThreadBrowserMode, ThreadPreviewItem } from '../main/threadBrowser';
+import type { ThreadBrowserMode, ThreadPreviewItem, ThreadCreateSource } from '../main/threadBrowser';
 
 const ipcRenderer = electron.ipcRenderer;
 
@@ -43,6 +44,8 @@ type InitResult = { ok: boolean; error?: string; mode?: ThreadBrowserMode; board
 type ListResult = { ok: boolean; error?: string; threads?: ThreadItem[] };
 type PreviewResult = { ok: boolean; error?: string; total?: number; comments?: ThreadPreviewItem[] };
 type ApplyResult = { ok: boolean; error?: string };
+type CreateSourceResult = { ok: boolean; error?: string; source?: ThreadCreateSource };
+type CreateResult = { ok: boolean; error?: string; newThreadUrl?: string };
 
 const mode: ThreadBrowserMode = new URLSearchParams(location.search).get('mode') === 'jpnkn' ? 'jpnkn' : 'bbs';
 
@@ -57,6 +60,161 @@ const PreviewComment: React.FC<{ item: ThreadPreviewItem }> = ({ item }) => (
     </Typography>
   </Box>
 );
+
+/**
+ * スレ立てダイアログ。編集 → 確認 → 実行 の2ステップ。
+ * 「戻る」で編集へ戻っても入力内容は保持される。
+ */
+const CreateThreadDialog: React.FC<{
+  open: boolean;
+  mode: ThreadBrowserMode;
+  boardUrl: string;
+  onClose: () => void;
+  onCreated: (newThreadUrl: string) => void;
+}> = ({ open, mode, boardUrl, onClose, onCreated }) => {
+  const [step, setStep] = React.useState<'edit' | 'confirm'>('edit');
+  const [title, setTitle] = React.useState('');
+  const [name, setName] = React.useState('');
+  const [mail, setMail] = React.useState('');
+  const [body, setBody] = React.useState('');
+  const [copyLoading, setCopyLoading] = React.useState(false);
+  const [submitting, setSubmitting] = React.useState(false);
+  const [error, setError] = React.useState('');
+
+  // 開くたびに編集ステップへ戻す (入力値は保持)
+  React.useEffect(() => {
+    if (open) {
+      setStep('edit');
+      setError('');
+    }
+  }, [open]);
+
+  const copyFromCurrent = async () => {
+    setCopyLoading(true);
+    setError('');
+    const res: CreateSourceResult = await ipcRenderer.invoke(electronEvent.THREAD_BROWSER_CREATE_SOURCE, { mode, boardUrl });
+    setCopyLoading(false);
+    if (!res.ok || !res.source) {
+      setError(res.error ?? 'コピー元の取得に失敗しました。');
+      return;
+    }
+    setTitle(res.source.title);
+    setName(res.source.name);
+    setMail(res.source.mail);
+    setBody(res.source.body);
+  };
+
+  const submit = async () => {
+    setSubmitting(true);
+    setError('');
+    const res: CreateResult = await ipcRenderer.invoke(electronEvent.THREAD_BROWSER_CREATE, { boardUrl, title, name, mail, body });
+    setSubmitting(false);
+    if (!res.ok) {
+      setError(res.error ?? 'スレッドの作成に失敗しました。');
+      return;
+    }
+    // 成功: 入力をクリアして親へ通知
+    setTitle('');
+    setName('');
+    setMail('');
+    setBody('');
+    setStep('edit');
+    onCreated(res.newThreadUrl ?? '');
+  };
+
+  const canProceed = title.trim().length > 0 && body.trim().length > 0;
+
+  return (
+    <Dialog open={open} onClose={() => (submitting ? undefined : onClose())} maxWidth="md" fullWidth>
+      {step === 'edit' ? (
+        <>
+          <DialogTitle>スレッドを作成</DialogTitle>
+          <DialogContent>
+            <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
+              <Button size="small" variant="outlined" onClick={copyFromCurrent} disabled={copyLoading} startIcon={copyLoading ? <CircularProgress size={14} /> : undefined}>
+                {mode === 'jpnkn' ? '最新のスレッドからコピー' : '現在のスレッドからコピー'}
+              </Button>
+            </Box>
+            <TextField label="タイトル" fullWidth size="small" value={title} onChange={(e) => setTitle(e.target.value)} sx={{ mb: 1.5 }} />
+            <Box sx={{ display: 'flex', gap: 1.5, mb: 1.5 }}>
+              <TextField label="名前 (空欄可)" size="small" fullWidth value={name} onChange={(e) => setName(e.target.value)} />
+              <TextField label="メール (空欄可)" size="small" fullWidth value={mail} onChange={(e) => setMail(e.target.value)} />
+            </Box>
+            <TextField label="本文 (1レス目)" fullWidth multiline minRows={8} value={body} onChange={(e) => setBody(e.target.value)} />
+            {error && (
+              <Alert severity="error" sx={{ mt: 1 }}>
+                {error}
+              </Alert>
+            )}
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={onClose}>キャンセル</Button>
+            <Button
+              variant="contained"
+              disabled={!canProceed}
+              onClick={() => {
+                setError('');
+                setStep('confirm');
+              }}
+            >
+              作成
+            </Button>
+          </DialogActions>
+        </>
+      ) : (
+        <>
+          <DialogTitle>スレッド作成の確認</DialogTitle>
+          <DialogContent>
+            <Typography variant="body2" sx={{ mb: 1.5 }}>
+              以下の内容でスレッドを作成します。よろしいですか?
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              タイトル
+            </Typography>
+            <Typography variant="body2" sx={{ fontWeight: 'bold', mb: 1, wordBreak: 'break-word' }}>
+              {title}
+            </Typography>
+            <Box sx={{ display: 'flex', gap: 3, mb: 1 }}>
+              <Box>
+                <Typography variant="caption" color="text.secondary">
+                  名前
+                </Typography>
+                <Typography variant="body2">{name || '(空欄)'}</Typography>
+              </Box>
+              <Box>
+                <Typography variant="caption" color="text.secondary">
+                  メール
+                </Typography>
+                <Typography variant="body2">{mail || '(空欄)'}</Typography>
+              </Box>
+            </Box>
+            <Typography variant="caption" color="text.secondary">
+              本文
+            </Typography>
+            <Box sx={{ border: '1px solid #ddd', borderRadius: 1, p: 1, maxHeight: 260, overflowY: 'auto' }}>
+              <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                {body}
+              </Typography>
+            </Box>
+            {error && (
+              <Alert severity="error" sx={{ mt: 1 }}>
+                {error}
+              </Alert>
+            )}
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setStep('edit')} disabled={submitting}>
+              戻る
+            </Button>
+            <Button variant="contained" onClick={submit} disabled={submitting} startIcon={submitting ? <CircularProgress size={14} /> : undefined}>
+              OK (作成する)
+            </Button>
+          </DialogActions>
+        </>
+      )}
+    </Dialog>
+  );
+};
 
 const ThreadBrowserApp: React.FC = () => {
   const [boardName, setBoardName] = React.useState('');
@@ -73,6 +231,7 @@ const ThreadBrowserApp: React.FC = () => {
   const [previewLoading, setPreviewLoading] = React.useState(false);
 
   const [confirmTarget, setConfirmTarget] = React.useState<ThreadItem | null>(null);
+  const [createOpen, setCreateOpen] = React.useState(false);
   const [snackbar, setSnackbar] = React.useState('');
 
   const loadList = React.useCallback(async (url: string) => {
@@ -208,17 +367,37 @@ const ThreadBrowserApp: React.FC = () => {
         </Box>
       </Box>
 
-      {/* フッター: スレ移動 (bbs のみ) */}
-      {mode === 'bbs' && (
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 1.5, py: 1, borderTop: '1px solid #ddd' }}>
-          <Typography variant="caption" color="text.secondary" sx={{ flexGrow: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-            {selectedThread ? selectedThread.url : 'スレッドを選択してください'}
-          </Typography>
+      {/* フッター: スレ作成 (両モード) + スレ移動 (bbs のみ) */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 1.5, py: 1, borderTop: '1px solid #ddd' }}>
+        <Typography variant="caption" color="text.secondary" sx={{ flexGrow: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {mode === 'bbs' ? (selectedThread ? selectedThread.url : 'スレッドを選択してください') : ''}
+        </Typography>
+        <Button variant="outlined" size="small" disabled={!boardUrl} onClick={() => setCreateOpen(true)}>
+          スレッドを作成
+        </Button>
+        {mode === 'bbs' && (
           <Button variant="contained" size="small" disabled={!selectedThread || selectedThread.url === currentThreadUrl} onClick={() => setConfirmTarget(selectedThread ?? null)}>
             このスレッドに移動
           </Button>
-        </Box>
-      )}
+        )}
+      </Box>
+
+      {/* スレ立てダイアログ */}
+      <CreateThreadDialog
+        open={createOpen}
+        mode={mode}
+        boardUrl={boardUrl}
+        onClose={() => setCreateOpen(false)}
+        onCreated={async (newThreadUrl) => {
+          setCreateOpen(false);
+          setSnackbar('スレッドを作成しました');
+          await loadList(boardUrl);
+          if (newThreadUrl) {
+            // 作成したスレを選択状態にしてプレビュー表示する (移動は自動では行わない)
+            openPreview({ url: newThreadUrl, name: '', resNum: 0 });
+          }
+        }}
+      />
 
       {/* 移動確認ダイアログ */}
       <Dialog open={!!confirmTarget} onClose={() => setConfirmTarget(null)}>


### PR DESCRIPTION
## 概要

- bbs (5ch互換 / したらば) と jpnkn の両方で、unacast 上からスレッドを作成できるようにする。

### その他

- 送信中はダイアログを閉じられない (二重送信防止)。
- エラーはダイアログ内に表示され、[戻る] で修正して再実行できる
- 本文の改行は `\r\n` に正規化して送信
