### PR TITLE
掲示板スレURLのレス範囲表記 (l50 / 127n- 等) を自動補正

### DIFF
--- a/src/main/startServer.ts
+++ b/src/main/startServer.ts
@@ -7,7 +7,7 @@ import { ChatClient } from 'dank-twitch-irc';
 import { LiveChat } from './youtube-chat';
 import { ipcMain } from 'electron';
 import expressWs from 'express-ws';
-import { readWavFiles, sleep, escapeHtml, unescapeHtml, decodeNumericCharRefs, removeEmoji, judgeAaMessage, isNihongo, convertUrltoImgTagSrc } from './util';
+import { readWavFiles, sleep, escapeHtml, unescapeHtml, decodeNumericCharRefs, removeEmoji, judgeAaMessage, isNihongo, convertUrltoImgTagSrc, normalizeThreadUrl } from './util';
 import { filterByAxis } from './sourceFilter';
 import { judgeNgWord } from './ngWord';
 import { getThreadFirstPost, createThreadOnBoard } from './threadBrowser';
@@ -90,6 +90,10 @@ ipcMain.on(electronEvent.LOAD_VOICEVOX, async (event: any, config_voicevox: (typ
 ipcMain.on(electronEvent.APPLY_CONFIG, async (event: any, config: (typeof globalThis)['config']) => {
   log.info('[apply-config] start');
   log.info(config);
+
+  // スレURLの表記補正 (l50 / 127n- 等のレス範囲表記を除去)。renderer 側でも補正するが、
+  // 旧設定の持ち込み等に備えて main 側でも通す
+  config.url = normalizeThreadUrl(config.url ?? '');
 
   // サーバー起動前に「適用」を押された場合 globalThis.config は未初期化なので、
   // 差分判定は optional chaining で安全に取り、未初期化なら「全部新規」とみなす。
@@ -176,6 +180,9 @@ ipcMain.on(electronEvent.START_SERVER, async (event: any, config: (typeof global
   app.set('view engine', 'ejs');
   // viewディレクトリの指定
   app.set('views', path.resolve(__dirname, '../../views'));
+
+  // スレURLの表記補正 (l50 / 127n- 等のレス範囲表記を除去)
+  config.url = normalizeThreadUrl(config.url ?? '');
 
   // 設定情報をグローバル変数へセットする
   globalThis.config = config;

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -89,6 +89,29 @@ export const convertUrltoImgTagSrc = (imgUrl: string) => {
   return imgUrl;
 };
 
+/**
+ * 掲示板スレURLの正規化。
+ *
+ * ブラウザのスレ一覧からスレを開くと、URL末尾にレス範囲の表記が付くことがある:
+ *   .../read.cgi/carbonara/1558097910/l50    (最新50レス)
+ *   .../read.cgi/carbonara/1558097910/127n-  (レス127以降)
+ *   .../read.cgi/carbonara/1558097910/2-100  (範囲指定)
+ * これらはコメントビューアの読み込みURLとしては不要なので、スレキー
+ * (read.cgi 後の9〜10桁の数値セグメント) までに切り詰めて
+ * 「.../read.cgi/{板}/{スレキー}/」の形へ補正する。個別表記の列挙ではなく
+ * スレキー以降を一括で除去するため、上記以外の表記にも耐える。
+ *
+ * read.cgi 形式でないURL (板URL等) は、前後空白と ?/# 以降の除去のみ行う。
+ */
+export const normalizeThreadUrl = (rawUrl: string): string => {
+  const url = rawUrl.trim().replace(/[?#].*$/, '');
+  const matched = url.match(/^(https?:\/\/[^/]+\/.*?read\.cgi\/.+?\/\d{9,10})(?:\/.*)?$/);
+  if (matched) {
+    return `${matched[1]}/`;
+  }
+  return url;
+};
+
 export const judgeAaMessage = (messageList: UserComment[]) => {
   return messageList.map((message) => {
     let isAA = false;

--- a/src/renderer/app/sections/Sources.tsx
+++ b/src/renderer/app/sections/Sources.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Box, Button, TextField, Typography } from '@mui/material';
 import { useAppStore } from '../store';
 import { sendOpenThreadBrowser } from '../ipc';
+import { normalizeThreadUrl } from '../../../main/util';
 import { SectionPanel, LabeledInput, Caption, SourceFilterToggle, StatusDot, getStatusColor } from './common';
 
 /**
@@ -40,6 +41,11 @@ export const Sources: React.FC = () => {
           size="small"
           value={config.url}
           onChange={(e) => setConfig('url', e.target.value)}
+          onBlur={() => {
+            // ブラウザからコピーしたURLに付く l50 / 127n- 等のレス範囲表記を自動補正する
+            const normalized = normalizeThreadUrl(config.url);
+            if (normalized !== config.url) setConfig('url', normalized);
+          }}
           inputProps={{ pattern: 'http.?://.+/$' }}
           placeholder="http(s)://.../"
         />


### PR DESCRIPTION
## 概要

ブラウザのスレ一覧からスレを開くと、URL 末尾にレス範囲の表記が付く

- `/l50` (最新50レス)
- `/127n-` (レス127以降)
- `/2-100` (範囲指定)

これをそのまま掲示板URLに貼ると読み込みに失敗して警告が出ていたが、unacast 側で自動補正して読み込めるようにした。

## 自動補正の経路

1. **設定画面の掲示板URL入力欄**: フォーカスアウト時に自動補正
2. **main 側の適用 / サーバー起動時**: 旧設定の持ち込みや別経路に備えた保険