### PR TITLE
読み上げの分割・省略ラインとVOICEVOX新バージョン対応

### DIFF
--- a/src/main/speechText.ts
+++ b/src/main/speechText.ts
@@ -1,0 +1,144 @@
+/**
+ * 読み上げテキストの分割・省略の純粋関数群。
+ *
+ * main プロセスの読み上げパイプライン (startServer.ts) と renderer の設定 UI の
+ * 両方から import できるよう、Electron 依存を持たない (ngWord.ts / yomikoTemplate.ts と同じ流儀)。
+ */
+
+export type SplitOptions = {
+  /** 最初のチャンクの目標上限 (コードポイント数)。第一声までの合成時間 = 体感レイテンシなので小さくする */
+  firstChunkMax: number;
+  /** 2番目以降のチャンクの目標上限。再生中に合成できるので大きくして合成回数を減らす */
+  chunkMax: number;
+  /** これ未満の短片は隣の文と結合する (「はい。」等が単独チャンクにならないように) */
+  minChunk: number;
+};
+
+/**
+ * 分割パラメータの既定値。
+ * 文境界で切る限り韻律への影響は小さく、1チャンクに収まる場合は完全に従来動作のため、
+ * 現時点では config 化しない (実機で問題が出た場合に設定化する余地あり)。
+ */
+export const DEFAULT_SPLIT_OPTIONS: SplitOptions = {
+  firstChunkMax: 40,
+  chunkMax: 120,
+  minChunk: 10,
+};
+
+/** 文末とみなす文字。区切り文字は直前の文に残す (「？」を落とすと疑問文イントネーションが効かなくなる) */
+const SENTENCE_ENDINGS = new Set(['。', '．', '！', '？', '!', '?', '…']);
+/** 文中の切れ目候補 (長文の二次分割で使う)。こちらも直前側に残す */
+const CLAUSE_BREAKS = new Set(['、', ',', '，', ' ', '　']);
+
+/** 文末記号・改行で文単位に分割する。区切り記号は直前の文に含める。空片は除く */
+const splitToSentences = (text: string): string[] => {
+  const sentences: string[] = [];
+  let current = '';
+  // サロゲートペアを壊さないようコードポイント単位で走査する
+  for (const ch of text) {
+    if (ch === '\n' || ch === '\r') {
+      if (current.trim()) sentences.push(current);
+      current = '';
+      continue;
+    }
+    current += ch;
+    if (SENTENCE_ENDINGS.has(ch)) {
+      if (current.trim()) sentences.push(current);
+      current = '';
+    }
+  }
+  if (current.trim()) sentences.push(current);
+  return sentences;
+};
+
+/** 1文が max を超える場合、max 以内の最後の句読点・空白で切る。無ければ max で機械的に切る */
+const splitLongSentence = (sentence: string, max: number): string[] => {
+  const cps = Array.from(sentence);
+  if (cps.length <= max) return [sentence];
+  const result: string[] = [];
+  let rest = cps;
+  while (rest.length > max) {
+    let cut = -1;
+    for (let i = max - 1; i > 0; i--) {
+      if (CLAUSE_BREAKS.has(rest[i])) {
+        cut = i + 1; // 句読点は直前側に含める
+        break;
+      }
+    }
+    if (cut <= 0) cut = max;
+    result.push(rest.slice(0, cut).join(''));
+    rest = rest.slice(cut);
+  }
+  if (rest.length > 0) result.push(rest.join(''));
+  return result;
+};
+
+const cpLength = (text: string): number => Array.from(text).length;
+
+/**
+ * 読み上げテキストをチャンクに分割する。
+ *
+ * - 文末記号 (。．！？!?…) と改行で文単位に分ける
+ * - 1文が chunkMax を超える場合は句読点・空白 (無ければ機械的) で二次分割
+ * - 第1チャンクは firstChunkMax 以内、以降は chunkMax 以内で文をまとめる
+ * - minChunk 未満の断片は隣と結合する
+ * - 全体が firstChunkMax 以内、または結果が1チャンクの場合は [text] を返す (従来動作と同一)
+ */
+export const splitYomikoText = (text: string, opts: SplitOptions = DEFAULT_SPLIT_OPTIONS): string[] => {
+  if (!text || cpLength(text) <= opts.firstChunkMax) return [text];
+
+  const sentences = splitToSentences(text).flatMap((s) => splitLongSentence(s, opts.chunkMax));
+  if (sentences.length === 0) return [text];
+
+  // 文を貪欲にまとめてチャンク化する (文間の間は読み子側の句読点処理に任せ、そのまま連結する)
+  const chunks: string[] = [];
+  let current = '';
+  for (const sentence of sentences) {
+    const limit = chunks.length === 0 ? opts.firstChunkMax : opts.chunkMax;
+    if (current === '') {
+      current = sentence;
+    } else if (cpLength(current) + cpLength(sentence) <= limit || cpLength(current) < opts.minChunk) {
+      // 上限に収まる、または現チャンクが短すぎる場合は結合する
+      current += sentence;
+    } else {
+      chunks.push(current);
+      current = sentence;
+    }
+  }
+  if (current !== '') {
+    // 末尾の短片は前のチャンクに結合する
+    if (cpLength(current) < opts.minChunk && chunks.length > 0) {
+      chunks[chunks.length - 1] += current;
+    } else {
+      chunks.push(current);
+    }
+  }
+
+  if (chunks.length <= 1) return [text];
+  return chunks;
+};
+
+export type YomikoOmitConfig = {
+  /** 省略機能を使うか */
+  enable: boolean;
+  /** この文字数 (コードポイント) を超えたら省略する */
+  maxLength: number;
+};
+
+/** 省略時に末尾へ付ける文言 */
+export const OMIT_SUFFIX = '、以下省略';
+
+/**
+ * 読み上げ省略ラインを適用する。
+ * テンプレート展開・辞書置換など全整形が終わった最終テキストに対して文字数を数え、
+ * maxLength を超えていたら先頭 maxLength 文字 + 「、以下省略」に切り詰める。
+ * cfg が未定義 (旧設定の持ち込みや main 未初期化) の場合は何もしない。
+ */
+export const applyYomikoOmit = (text: string, cfg: YomikoOmitConfig | undefined): string => {
+  if (!cfg?.enable) return text;
+  const maxLength = Math.floor(cfg.maxLength);
+  if (!Number.isFinite(maxLength) || maxLength <= 0) return text;
+  const cps = Array.from(text);
+  if (cps.length <= maxLength) return text;
+  return cps.slice(0, maxLength).join('') + OMIT_SUFFIX;
+};

--- a/src/main/startServer.ts
+++ b/src/main/startServer.ts
@@ -13,6 +13,7 @@ import { judgeNgWord } from './ngWord';
 import { getThreadFirstPost, createThreadOnBoard, getThreadResCount } from './threadBrowser';
 import { incrementThreadTitle } from './readBBS/createThread';
 import { resolveYomikoTemplate, applyYomikoTemplate } from './yomikoTemplate';
+import { splitYomikoText, applyYomikoOmit } from './speechText';
 import { registerExternalApiRoutes } from './externalApi/routes';
 // レス取得APIをセット
 import getRes, { getRes as getBbsResponse, getThreadList, threadUrlToBoardInfo } from './getRes';
@@ -63,11 +64,14 @@ let serverId = 0;
  */
 const loadVoiceVox = async (config_voicevox: (typeof config)['voicevox'], force = false) => {
   if (!voiceVox?.available || force) {
-    voiceVox = new VoiceVoxClient({ path: config_voicevox.path });
+    voiceVox = new VoiceVoxClient({ path: config_voicevox.path, engineUrl: config_voicevox.engineUrl });
+    // DLL が読めない場合はエンジン HTTP API へのフォールバックを試す
+    await voiceVox.init();
   }
   const configuration = {
     path: voiceVox.path,
     available: voiceVox.available,
+    mode: voiceVox.mode,
     speakerAndStyle: config_voicevox.speakerAndStyle,
     speakers: voiceVox.speakers.reduce((state: { speaker: string; style: string }[], speaker) => {
       return state.concat(
@@ -144,8 +148,8 @@ ipcMain.on(electronEvent.APPLY_CONFIG, async (event: any, config: (typeof global
   // VOICE VOX 関連
   if (config.typeYomiko === 'voicevox' || config.typeYomikoStt === 'voicevox') {
     // VOICEVOX 利用の場合のみ
-    if (oldConfig?.voicevox?.path !== config.voicevox?.path) {
-      // VOICEVOX 読み込み先パスが変わっていれば強制読み込み直し
+    if (oldConfig?.voicevox?.path !== config.voicevox?.path || oldConfig?.voicevox?.engineUrl !== config.voicevox?.engineUrl) {
+      // VOICEVOX 読み込み先パス・エンジンURLが変わっていれば強制読み込み直し
       loadVoiceVox(config.voicevox, true);
     } else {
       // パスが変わっていない場合は未読み込みの時だけ読み込む
@@ -470,9 +474,12 @@ ipcMain.on(electronEvent.START_SERVER, async (event: any, config: (typeof global
       if (!voiceVox?.available) {
         voiceVox = new VoiceVoxClient({
           path: config.voicevox.path,
+          engineUrl: config.voicevox.engineUrl,
           speaker: config.voicevox.speakerAndStyle,
           volume: config.bouyomiVolume,
         });
+        // DLL が読めない場合はエンジン HTTP API へのフォールバックを試す
+        await voiceVox.init();
       } else {
         voiceVox.speaker = config.voicevox.speakerAndStyle;
         voiceVox.volume = config.bouyomiVolume;
@@ -1179,9 +1186,55 @@ const translateTaskScheduler = async (exeId: number) => {
 
 /** 読み子によって発話中であるか */
 let isSpeaking = false;
+/**
+ * 発話の世代。playYomiko が呼ばれるたびに増える。
+ * 分割読み上げのチャンクループは自分の世代と一致しなくなった時点で自発的に停止する
+ * (commentProcessType=0 で並走する後続の発話が来た場合の中断用)。
+ */
+let speechGeneration = 0;
+
+/**
+ * VOICEVOX の分割読み上げ。
+ * テキストを文単位のチャンクに分割し、先頭チャンクの再生中に次のチャンクを合成することで
+ * 第一声までの時間を短くする。1チャンクに収まる短文は従来と同じ一括合成・再生になる。
+ *
+ * 注意: DLL 接続 (FFI) の場合は合成が main プロセスをブロックする (従来の全文一括合成と同じ制約。
+ * 再生自体は renderer の audio 要素なので途切れない)。エンジン HTTP API 接続の場合は非同期。
+ * 将来課題: FFI 合成の worker_threads 化。
+ */
+const speakVoicevoxChunked = async (msg: string, gen: number) => {
+  const chunks = splitYomikoText(msg);
+  if (chunks.length > 1) log.info(`[playYomiko] voicevox 分割読み上げ (${chunks.length}チャンク)`);
+  // 先頭チャンクを合成 (プレフィックスは先頭のみ)
+  let next = await voiceVox.synthesize(chunks[0], true);
+  for (let i = 0; i < chunks.length; i++) {
+    if (gen !== speechGeneration) return; // 新しい発話に中断された (isSpeaking は新しい発話の所有物なので触らない)
+    const buf = next;
+    next = null;
+    if (buf) {
+      isSpeaking = true;
+      voiceVox.playWav(buf);
+    }
+    // 再生中に次のチャンクを合成しておく
+    if (i + 1 < chunks.length) {
+      next = await voiceVox.synthesize(chunks[i + 1], false);
+    }
+    if (buf) {
+      // このチャンクの再生完了 (SPEAKING_END) または中断を待つ。
+      // 合成に失敗したチャンクは再生していないので待たずに次へ (待つと SPEAKING_END が来ずハングする)
+      while (isSpeaking && gen === speechGeneration) {
+        await sleep(50);
+      }
+      if (gen !== speechGeneration) return;
+    }
+  }
+  isSpeaking = false;
+};
+
 /** 読み子を再生する */
 const playYomiko = async (typeYomiko: typeof config.typeYomiko, msg: string) => {
   // log.info('[playYomiko] start');
+  const gen = ++speechGeneration;
   if (isSpeaking) {
     // 以前の読み子がまだ読んでいる
     switch (typeYomiko) {
@@ -1223,7 +1276,9 @@ const playYomiko = async (typeYomiko: typeof config.typeYomiko, msg: string) => 
     }
     case 'voicevox': {
       if (voiceVox) {
-        voiceVox.speak(msg);
+        // 分割読み上げ (全チャンクの再生完了まで待つので、末尾の while は使わない)
+        await speakVoicevoxChunked(msg, gen);
+        return;
       } else {
         isSpeaking = false;
       }
@@ -1458,6 +1513,8 @@ export const sendDom = async (messageList: UserComment[]) => {
           }
           text = t;
         }
+        // 読み上げ省略ライン (全読み子共通。最終整形後のテキストの文字数で判定する)
+        text = applyYomikoOmit(text, globalThis.config.yomikoOmit);
         // テンプレート展開の結果が空 (本文が絵文字のみ等) なら読み上げない
         if (text.trim()) {
           await playYomiko(typeYomiko, text);

--- a/src/main/voicevox/index.ts
+++ b/src/main/voicevox/index.ts
@@ -294,10 +294,20 @@ class VoiceVoxCore_0_16 implements IVoiceVoxCore {
         log.error(`[voicevox] 音声モデルディレクトリが見つかりません (path=${libpath})`);
         return;
       }
-      const vvmFiles = fs
-        .readdirSync(modelDir)
-        .filter((f) => f.endsWith('.vvm'))
-        .map((f) => path.join(modelDir, f));
+      const listVvm = (dir: string) =>
+        fs
+          .readdirSync(dir)
+          .filter((f) => f.endsWith('.vvm'))
+          .map((f) => path.join(dir, f));
+      let vvmFiles = listVvm(modelDir);
+      if (vvmFiles.length === 0) {
+        // 配布形態によっては model 直下でなくサブディレクトリに置かれるため、1階層下も探す
+        vvmFiles = fs
+          .readdirSync(modelDir)
+          .map((f) => path.join(modelDir, f))
+          .filter((p) => fs.statSync(p).isDirectory())
+          .flatMap(listVvm);
+      }
       const speakers: VoiceVoxSpeaker[] = [];
       for (const vvmPath of vvmFiles) {
         const model = [null];
@@ -518,16 +528,29 @@ class VoiceVoxClient {
       // macOS の場合は
       // * /Applications/VOICEVOX/VOICEVOX.app/Contents/MacOS
       // * $HOME/Applications/VOICEVOX/VOICEVOX.app/Contents/MacOS
-      // のいずれか
+      // のいずれか (新しめのバージョンはエンジンが Resources/vv-engine 配下にある)
       const appDir = '/Applications/VOICEVOX/VOICEVOX.app/Contents/MacOS';
       const userAppDir = path.join(os.homedir(), '/Applications/VOICEVOX/VOICEVOX.app/Contents/MacOS');
 
       const search_paths = voicevox_path ? [voicevox_path] : [appDir, userAppDir];
       voicevox_path = search_paths.find((p) => fs.existsSync(path.join(p, 'libvoicevox_core.dylib'))) || '';
+      if (!voicevox_path) {
+        const engineDirs = search_paths.flatMap((p) => [path.join(p, 'vv-engine'), path.join(p, '..', 'Resources', 'vv-engine')]);
+        voicevox_path = engineDirs.find((p) => fs.existsSync(path.join(p, 'libvoicevox_core.dylib'))) || '';
+      }
     }
 
     try {
-      const voicevox_core = koffi.load('voicevox_core');
+      // まずライブラリ名での読み込み (Windows は SetDllDirectoryW 済みなので通る)。
+      // 通らない場合は見つけたインストール先のフルパスで試す (macOS 等は検索パスに乗らないため)
+      let voicevox_core: IKoffiLib;
+      try {
+        voicevox_core = koffi.load('voicevox_core');
+      } catch (e) {
+        if (!voicevox_path) throw e;
+        const libName = os.platform() === 'win32' ? 'voicevox_core.dll' : os.platform() === 'darwin' ? 'libvoicevox_core.dylib' : 'libvoicevox_core.so';
+        voicevox_core = koffi.load(path.join(voicevox_path, libName));
+      }
       const voicevox_get_version = voicevox_core.func('string voicevox_get_version()');
       const version = voicevox_get_version()
         .split('.')

--- a/src/main/voicevox/index.ts
+++ b/src/main/voicevox/index.ts
@@ -1,11 +1,15 @@
 import { electronEvent } from '../const';
 import koffi, { IKoffiLib } from 'koffi';
+import axios from 'axios';
 import os from 'os';
 import path from 'path';
 import fs from 'fs';
+import log from 'electron-log';
 
 type Options = {
   path?: string;
+  /** エンジン HTTP API の URL。空の場合は既定 (http://127.0.0.1:50021) */
+  engineUrl?: string;
   speaker?: string;
   prefix?: string;
   volume?: number;
@@ -26,6 +30,9 @@ type VoiceVoxSpeaker = {
   version: string;
 };
 
+/** 接続方式。UI 表示用 */
+export type VoiceVoxMode = 'none' | 'dll-0.15' | 'dll-0.16' | 'http';
+
 interface IVoiceVoxCore {
   /**
    * 利用可能かどうか
@@ -35,6 +42,10 @@ interface IVoiceVoxCore {
    * 読み込んだ VOICEVOX で利用できる話者のリスト。
    */
   speakers: VoiceVoxSpeaker[];
+  /**
+   * 接続方式
+   */
+  mode: VoiceVoxMode;
 
   speak(opts: Options, message: string): Promise<Uint8Array | null>;
 }
@@ -42,37 +53,65 @@ interface IVoiceVoxCore {
 class UnavailableVoiceVoxCore implements IVoiceVoxCore {
   public available: boolean = false;
   public speakers: VoiceVoxSpeaker[] = [];
+  public mode: VoiceVoxMode = 'none';
   async speak(_opts: Options, _message: string) {
     return null;
   }
 }
 
+/** 話者設定文字列 (「話者名\スタイル名」) からスタイル ID を解決する。見つからなければ先頭の話者・スタイルに寄せる */
+const resolveStyleId = (speakers: VoiceVoxSpeaker[], speakerAndStyle: string | undefined): number | null => {
+  const [speakerName, styleName] = (speakerAndStyle ?? '\\').split('\\');
+  const speaker = speakers.find((s) => s.name === speakerName) || speakers[0];
+  if (!speaker) return null;
+  const style = speaker.styles.find((s) => s.name === styleName) || speaker.styles[0];
+  if (!style) return null;
+  return style.id;
+};
+
+/**
+ * koffi の名前付き型はプロセス内で一意である必要があり、二重登録は例外になる。
+ * VoiceVoxClient は再読み込みで複数回構築されるため、struct 定義は一度だけ行う。
+ */
+let structs015: { VoicevoxInitializeOptions: any; VoicevoxAudioQueryOptions: any; VoicevoxSynthesisOptions: any } | null = null;
+const getStructs015 = () => {
+  if (!structs015) {
+    structs015 = {
+      VoicevoxInitializeOptions: koffi.struct('VoicevoxInitializeOptions', {
+        accelerationMode: 'int',
+        cpuNumThreads: 'uint16',
+        loadAllModels: 'bool',
+        openJTalkDictDir: 'string',
+      }),
+      VoicevoxAudioQueryOptions: koffi.struct('VoicevoxAudioQueryOptions', {
+        kana: 'bool',
+      }),
+      VoicevoxSynthesisOptions: koffi.struct('VoicevoxSynthesisOptions', {
+        enable_interrogative_upspeak: 'bool',
+      }),
+    };
+    // koffi 側にスキーマだけ登録しておく（現状コードからは未使用）
+    koffi.struct('VoicevoxTtsOptions', {
+      kana: 'bool',
+      enable_interrogative_upspeak: 'bool',
+    });
+  }
+  return structs015;
+};
+
+/** 0.15 用: 解放関数付き JSON 文字列型 (これも名前付きなので一度だけ登録する) */
+let audioQueryJsonType015: any = null;
+
 class VoiceVoxCore_0_15 implements IVoiceVoxCore {
   constructor(libpath: string, lib: IKoffiLib) {
-    const VoicevoxInitializeOptions = koffi.struct('VoicevoxInitializeOptions', {
-      accelerationMode: 'int',
-      cpuNumThreads: 'uint16',
-      loadAllModels: 'bool',
-      openJTalkDictDir: 'string',
-    });
-
-    const VoicevoxAudioQueryOptions = koffi.struct('VoicevoxAudioQueryOptions', {
-      kana: 'bool',
-    });
-
-    const VoicevoxSynthesisOptions = koffi.struct('VoicevoxSynthesisOptions', {
-      enable_interrogative_upspeak: 'bool',
-    });
-
-    // koffi 側にスキーマだけ登録しておく（現状コードからは未使用）
-    const _VoicevoxTtsOptions = koffi.struct('VoicevoxTtsOptions', {
-      kana: 'bool',
-      enable_interrogative_upspeak: 'bool',
-    });
+    const { VoicevoxInitializeOptions, VoicevoxAudioQueryOptions, VoicevoxSynthesisOptions } = getStructs015();
 
     try {
-      const voicevox_audio_query_json_free = lib.func('voicevox_audio_query_json_free', 'void', ['void*']);
-      const audio_query_json_type = koffi.disposable('audio_query_json_type', 'string', voicevox_audio_query_json_free);
+      if (!audioQueryJsonType015) {
+        const voicevox_audio_query_json_free = lib.func('voicevox_audio_query_json_free', 'void', ['void*']);
+        audioQueryJsonType015 = koffi.disposable('audio_query_json_type', 'string', voicevox_audio_query_json_free);
+      }
+      const audio_query_json_type = audioQueryJsonType015;
       this.voicevox_core = {
         voicevox_initialize: lib.func('voicevox_initialize', 'int', [VoicevoxInitializeOptions]),
         voicevox_get_metas_json: lib.func('voicevox_get_metas_json', 'string', []),
@@ -114,10 +153,11 @@ class VoiceVoxCore_0_15 implements IVoiceVoxCore {
    * 読み込んだ VOICEVOX で利用できる話者のリスト。
    */
   public speakers: VoiceVoxSpeaker[];
+  public mode: VoiceVoxMode = 'dll-0.15';
   private voicevox_core: any;
 
   /**
-   * 読み上げを開始します。
+   * 音声を合成します。
    * @param opts VOICEVOX に読み上げオプション
    * @param message VOICEVOX に読み上げてもらう文章
    */
@@ -125,23 +165,19 @@ class VoiceVoxCore_0_15 implements IVoiceVoxCore {
     /** 読み前に文字列を処理する */
     const concatMessage = (opts.prefix ?? '').concat(message);
 
-    const speakerAndStyle = (opts.speaker ?? '\\').split('\\');
-    const speaker = this.speakers.find((speaker) => speaker.name === speakerAndStyle[0]) || this.speakers[0];
-    if (!speaker) {
+    const styleId = resolveStyleId(this.speakers, opts.speaker);
+    if (styleId === null) {
       return null;
     }
-    const style = speaker.styles.find((style) => style.name === speakerAndStyle[1]) || speaker.styles[0];
-    if (!style) {
-      return null;
-    }
-    if (!this.voicevox_core.voicevox_is_model_loaded(style.id)) {
-      this.voicevox_core.voicevox_load_model(style.id);
+    if (!this.voicevox_core.voicevox_is_model_loaded(styleId)) {
+      this.voicevox_core.voicevox_load_model(styleId);
     }
     const query_option = this.voicevox_core.voicevox_make_default_audio_query_options();
     const audio_query: [string | null] = [null];
-    if (this.voicevox_core.voicevox_audio_query(concatMessage, style.id, query_option, audio_query) == 0) {
+    if (this.voicevox_core.voicevox_audio_query(concatMessage, styleId, query_option, audio_query) == 0) {
       let audio_query_json: string = audio_query[0] ?? '';
       const audio_query_obj = JSON.parse(audio_query_json);
+      // core 0.15 の AudioQuery は snake_case
       audio_query_obj.speed_scale = opts.speed ?? 1.0;
       audio_query_obj.pitch_scale = opts.pitch ?? 0.0;
       audio_query_obj.intonation_scale = opts.intonation ?? 1.0;
@@ -151,7 +187,7 @@ class VoiceVoxCore_0_15 implements IVoiceVoxCore {
       };
       const len = [0];
       const wav = [null];
-      const result = this.voicevox_core.voicevox_synthesis(audio_query_json, style.id, synthesis_opts, len, wav);
+      const result = this.voicevox_core.voicevox_synthesis(audio_query_json, styleId, synthesis_opts, len, wav);
       if (result == 0) {
         const buf: Uint8Array = koffi.decode(wav[0], 'uint8', len[0]);
         this.voicevox_core.voicevox_wav_free(wav[0]);
@@ -159,6 +195,295 @@ class VoiceVoxCore_0_15 implements IVoiceVoxCore {
       }
     }
     return null;
+  }
+}
+
+/**
+ * voicevox_core 0.16 以降の C API 対応。
+ * 0.15 までと違い、onnxruntime・Open JTalk 辞書・音声モデル (.vvm) を明示的に読み込む必要がある。
+ * VOICEVOX アプリ同梱のエンジン (vv-engine) には core DLL・onnxruntime DLL・model/*.vvm が含まれる。
+ */
+/** 0.16 用の struct 定義 (一度だけ登録する) */
+let structs016: { VoicevoxLoadOnnxruntimeOptions: any; VoicevoxInitializeOptionsV16: any; VoicevoxSynthesisOptionsV16: any } | null = null;
+const getStructs016 = () => {
+  if (!structs016) {
+    structs016 = {
+      VoicevoxLoadOnnxruntimeOptions: koffi.struct('VoicevoxLoadOnnxruntimeOptions', {
+        filename: 'string',
+      }),
+      VoicevoxInitializeOptionsV16: koffi.struct('VoicevoxInitializeOptionsV16', {
+        acceleration_mode: 'int32',
+        cpu_num_threads: 'uint16',
+      }),
+      VoicevoxSynthesisOptionsV16: koffi.struct('VoicevoxSynthesisOptionsV16', {
+        enable_interrogative_upspeak: 'bool',
+      }),
+    };
+  }
+  return structs016;
+};
+
+/** 0.16 用: voicevox_json_free で解放する JSON 文字列型 (名前付きなので一度だけ登録する) */
+let jsonType016: any = null;
+
+class VoiceVoxCore_0_16 implements IVoiceVoxCore {
+  constructor(libpath: string, lib: IKoffiLib) {
+    try {
+      const { VoicevoxLoadOnnxruntimeOptions, VoicevoxInitializeOptionsV16, VoicevoxSynthesisOptionsV16 } = getStructs016();
+      if (!jsonType016) {
+        const voicevox_json_free = lib.func('voicevox_json_free', 'void', ['void*']);
+        jsonType016 = koffi.disposable('voicevox_json_type', 'string', voicevox_json_free);
+      }
+
+      const api = {
+        voicevox_make_default_load_onnxruntime_options: lib.func('voicevox_make_default_load_onnxruntime_options', VoicevoxLoadOnnxruntimeOptions, []),
+        voicevox_onnxruntime_load_once: lib.func('voicevox_onnxruntime_load_once', 'int', [VoicevoxLoadOnnxruntimeOptions, koffi.out('void**')]),
+        voicevox_open_jtalk_rc_new: lib.func('voicevox_open_jtalk_rc_new', 'int', ['string', koffi.out('void**')]),
+        voicevox_synthesizer_new: lib.func('voicevox_synthesizer_new', 'int', ['void*', 'void*', VoicevoxInitializeOptionsV16, koffi.out('void**')]),
+        voicevox_voice_model_file_open: lib.func('voicevox_voice_model_file_open', 'int', ['string', koffi.out('void**')]),
+        voicevox_voice_model_file_create_metas_json: lib.func('voicevox_voice_model_file_create_metas_json', jsonType016, ['void*']),
+        voicevox_voice_model_file_delete: lib.func('voicevox_voice_model_file_delete', 'void', ['void*']),
+        voicevox_synthesizer_load_voice_model: lib.func('voicevox_synthesizer_load_voice_model', 'int', ['void*', 'void*']),
+        voicevox_synthesizer_create_audio_query: lib.func('voicevox_synthesizer_create_audio_query', 'int', ['void*', 'string', 'uint32', koffi.out(koffi.pointer(jsonType016))]),
+        voicevox_synthesizer_synthesis: lib.func('voicevox_synthesizer_synthesis', 'int', [
+          'void*',
+          'string',
+          'uint32',
+          VoicevoxSynthesisOptionsV16,
+          koffi.out('uintptr_t*'),
+          koffi.out('uint8**'),
+        ]),
+        voicevox_wav_free: lib.func('voicevox_wav_free', 'void', ['uint8*']),
+      };
+      this.api = api;
+
+      // onnxruntime の読み込み (ファイル名は core が返す既定値。SetDllDirectoryW 済みなので DLL と同じディレクトリから解決される)
+      const onnxOpts = api.voicevox_make_default_load_onnxruntime_options();
+      const onnxruntime = [null];
+      const onnxResult = api.voicevox_onnxruntime_load_once(onnxOpts, onnxruntime);
+      if (onnxResult !== 0) {
+        log.error(`[voicevox] onnxruntime の読み込みに失敗 (code=${onnxResult})`);
+        return;
+      }
+
+      // Open JTalk 辞書ディレクトリの探索
+      const dictDir = this.findOpenJtalkDict(libpath);
+      if (!dictDir) {
+        log.error(`[voicevox] Open JTalk 辞書が見つかりません (path=${libpath})`);
+        return;
+      }
+      const openJtalk = [null];
+      const jtalkResult = api.voicevox_open_jtalk_rc_new(dictDir, openJtalk);
+      if (jtalkResult !== 0) {
+        log.error(`[voicevox] Open JTalk 辞書の読み込みに失敗 (code=${jtalkResult} dir=${dictDir})`);
+        return;
+      }
+
+      // シンセサイザの構築
+      const synthesizer = [null];
+      const synthResult = api.voicevox_synthesizer_new(onnxruntime[0], openJtalk[0], { acceleration_mode: 0, cpu_num_threads: 0 }, synthesizer);
+      if (synthResult !== 0) {
+        log.error(`[voicevox] synthesizer の構築に失敗 (code=${synthResult})`);
+        return;
+      }
+      this.synthesizer = synthesizer[0];
+
+      // 音声モデル (.vvm) の列挙とメタ情報の収集 (ロード自体は発話時に遅延実行する)
+      const modelDir = [path.join(libpath, 'model'), path.join(libpath, 'models')].find((p) => fs.existsSync(p));
+      if (!modelDir) {
+        log.error(`[voicevox] 音声モデルディレクトリが見つかりません (path=${libpath})`);
+        return;
+      }
+      const vvmFiles = fs
+        .readdirSync(modelDir)
+        .filter((f) => f.endsWith('.vvm'))
+        .map((f) => path.join(modelDir, f));
+      const speakers: VoiceVoxSpeaker[] = [];
+      for (const vvmPath of vvmFiles) {
+        const model = [null];
+        if (api.voicevox_voice_model_file_open(vvmPath, model) !== 0) {
+          log.warn(`[voicevox] vvm を開けませんでした: ${vvmPath}`);
+          continue;
+        }
+        try {
+          const metasJson = api.voicevox_voice_model_file_create_metas_json(model[0]);
+          const metas: VoiceVoxSpeaker[] = JSON.parse(metasJson);
+          for (const speaker of metas) {
+            for (const style of speaker.styles) {
+              this.styleIdToVvmPath.set(style.id, vvmPath);
+            }
+            // 同名話者が複数 vvm に分かれている場合はスタイルをマージする
+            const existing = speakers.find((s) => s.speaker_uuid === speaker.speaker_uuid);
+            if (existing) {
+              existing.styles = existing.styles.concat(speaker.styles.filter((st) => !existing.styles.some((es) => es.id === st.id)));
+            } else {
+              speakers.push(speaker);
+            }
+          }
+        } catch (e) {
+          log.warn(`[voicevox] vvm のメタ情報解析に失敗: ${vvmPath} ${e}`);
+        } finally {
+          api.voicevox_voice_model_file_delete(model[0]);
+        }
+      }
+      if (speakers.length === 0) {
+        log.error(`[voicevox] 利用可能な音声モデルがありません (dir=${modelDir})`);
+        return;
+      }
+      this.speakers = speakers;
+      this.available = true;
+      log.info(`[voicevox] core 0.16 系で初期化完了 (話者=${speakers.length} モデル=${vvmFiles.length})`);
+    } catch (e) {
+      log.error(`[voicevox] core 0.16 系の初期化に失敗: ${e}`);
+      this.available = false;
+      this.speakers = [];
+    }
+  }
+
+  public available = false;
+  public speakers: VoiceVoxSpeaker[] = [];
+  public mode: VoiceVoxMode = 'dll-0.16';
+  private api: any;
+  private synthesizer: any = null;
+  /** スタイル ID → vvm ファイルパス */
+  private styleIdToVvmPath = new Map<number, string>();
+  /** ロード済みの vvm ファイルパス */
+  private loadedVvmPaths = new Set<string>();
+
+  /** Open JTalk 辞書ディレクトリを探す */
+  private findOpenJtalkDict(libpath: string): string | null {
+    // 既知の配置: {engine}/pyopenjtalk/open_jtalk_dic_utf_8-1.11
+    const candidates = [path.join(libpath, 'pyopenjtalk'), libpath];
+    for (const dir of candidates) {
+      if (!fs.existsSync(dir)) continue;
+      try {
+        const found = fs
+          .readdirSync(dir)
+          .filter((f) => f.startsWith('open_jtalk_dic_utf_8'))
+          .map((f) => path.join(dir, f))
+          .find((p) => fs.statSync(p).isDirectory());
+        if (found) return found;
+      } catch {
+        // 読めないディレクトリはスキップ
+      }
+    }
+    return null;
+  }
+
+  async speak(opts: Options, message: string): Promise<Uint8Array | null> {
+    if (!this.available || !this.synthesizer) return null;
+    const concatMessage = (opts.prefix ?? '').concat(message);
+
+    const styleId = resolveStyleId(this.speakers, opts.speaker);
+    if (styleId === null) {
+      return null;
+    }
+
+    // 対象スタイルのモデルを遅延ロード
+    const vvmPath = this.styleIdToVvmPath.get(styleId);
+    if (vvmPath && !this.loadedVvmPaths.has(vvmPath)) {
+      const model = [null];
+      if (this.api.voicevox_voice_model_file_open(vvmPath, model) !== 0) {
+        log.error(`[voicevox] vvm を開けませんでした: ${vvmPath}`);
+        return null;
+      }
+      const loadResult = this.api.voicevox_synthesizer_load_voice_model(this.synthesizer, model[0]);
+      this.api.voicevox_voice_model_file_delete(model[0]);
+      if (loadResult !== 0) {
+        log.error(`[voicevox] 音声モデルのロードに失敗 (code=${loadResult} vvm=${vvmPath})`);
+        return null;
+      }
+      this.loadedVvmPaths.add(vvmPath);
+    }
+
+    const audioQueryOut = [null as string | null];
+    const queryResult = this.api.voicevox_synthesizer_create_audio_query(this.synthesizer, concatMessage, styleId, audioQueryOut);
+    if (queryResult !== 0) {
+      log.error(`[voicevox] audio query の生成に失敗 (code=${queryResult})`);
+      return null;
+    }
+    const audio_query_obj = JSON.parse(audioQueryOut[0] ?? '{}');
+    // core 0.16 の AudioQuery は camelCase (エンジン HTTP API と同じ形式)
+    audio_query_obj.speedScale = opts.speed ?? 1.0;
+    audio_query_obj.pitchScale = opts.pitch ?? 0.0;
+    audio_query_obj.intonationScale = opts.intonation ?? 1.0;
+
+    const len = [0];
+    const wav = [null];
+    const result = this.api.voicevox_synthesizer_synthesis(this.synthesizer, JSON.stringify(audio_query_obj), styleId, { enable_interrogative_upspeak: true }, len, wav);
+    if (result !== 0) {
+      log.error(`[voicevox] 音声合成に失敗 (code=${result})`);
+      return null;
+    }
+    const buf: Uint8Array = koffi.decode(wav[0], 'uint8', len[0]);
+    this.api.voicevox_wav_free(wav[0]);
+    return buf;
+  }
+}
+
+/** エンジン HTTP API の既定 URL (VOICEVOX アプリ起動中にエンジンが待ち受けるポート) */
+export const DEFAULT_VOICEVOX_ENGINE_URL = 'http://127.0.0.1:50021';
+
+/**
+ * VOICEVOX エンジンの HTTP API (既定 http://127.0.0.1:50021) を使う実装。
+ * DLL のバージョンに依存せず全バージョンで利用でき、AivisSpeech 等の互換エンジンも
+ * URL 設定で利用できる。VOICEVOX アプリ (エンジン) が起動している必要がある。
+ * 合成が HTTP 越しの非同期になるため、main プロセスをブロックしない利点もある。
+ */
+class VoiceVoxEngineApi implements IVoiceVoxCore {
+  constructor(engineUrl: string | undefined) {
+    this.baseUrl = (engineUrl || DEFAULT_VOICEVOX_ENGINE_URL).replace(/\/+$/, '');
+  }
+
+  public available = false;
+  public speakers: VoiceVoxSpeaker[] = [];
+  public mode: VoiceVoxMode = 'http';
+  private baseUrl: string;
+
+  /** エンジンへの疎通確認と話者一覧の取得。成功したら available になる */
+  async init(): Promise<void> {
+    try {
+      const version = await axios.get<string>(`${this.baseUrl}/version`, { timeout: 3000, proxy: false });
+      const speakers = await axios.get<VoiceVoxSpeaker[]>(`${this.baseUrl}/speakers`, { timeout: 5000, proxy: false });
+      this.speakers = speakers.data;
+      this.available = this.speakers.length > 0;
+      log.info(`[voicevox] エンジン HTTP API に接続 (${this.baseUrl} version=${version.data} 話者=${this.speakers.length})`);
+    } catch (e) {
+      log.info(`[voicevox] エンジン HTTP API に接続できません (${this.baseUrl}): ${e}`);
+      this.available = false;
+      this.speakers = [];
+    }
+  }
+
+  async speak(opts: Options, message: string): Promise<Uint8Array | null> {
+    if (!this.available) return null;
+    const concatMessage = (opts.prefix ?? '').concat(message);
+    const styleId = resolveStyleId(this.speakers, opts.speaker);
+    if (styleId === null) {
+      return null;
+    }
+    try {
+      const query = await axios.post(`${this.baseUrl}/audio_query`, null, {
+        params: { text: concatMessage, speaker: styleId },
+        timeout: 30 * 1000,
+        proxy: false,
+      });
+      const audioQuery = query.data;
+      // エンジン HTTP API の AudioQuery は camelCase
+      audioQuery.speedScale = opts.speed ?? 1.0;
+      audioQuery.pitchScale = opts.pitch ?? 0.0;
+      audioQuery.intonationScale = opts.intonation ?? 1.0;
+      const synthesis = await axios.post<ArrayBuffer>(`${this.baseUrl}/synthesis`, audioQuery, {
+        params: { speaker: styleId, enable_interrogative_upspeak: true },
+        responseType: 'arraybuffer',
+        timeout: 60 * 1000,
+        proxy: false,
+      });
+      return new Uint8Array(synthesis.data);
+    } catch (e) {
+      log.error(`[voicevox] エンジン HTTP API での合成に失敗: ${e}`);
+      return null;
+    }
   }
 }
 
@@ -212,9 +537,8 @@ class VoiceVoxClient {
       if (major === 0 && minor <= 15) {
         this.voicevox_core = new VoiceVoxCore_0_15(voicevox_path, voicevox_core);
       } else {
-        // VOICEVOX Core の 0.16 以降(VOICEVOXの0.16以降ではない)は API が変わっている。
-        // 未対応
-        this.voicevox_core = new UnavailableVoiceVoxCore();
+        // VOICEVOX Core の 0.16 以降(VOICEVOXの0.16以降ではない)は API が別物
+        this.voicevox_core = new VoiceVoxCore_0_16(voicevox_path, voicevox_core);
       }
       if (this.voicevox_core.available) {
         this.path = voicevox_path;
@@ -225,9 +549,23 @@ class VoiceVoxClient {
       this.voicevox_core = new UnavailableVoiceVoxCore();
       this.path = options?.path;
     }
+    this.engineUrl = options?.engineUrl ?? '';
     this.speaker = options?.speaker ?? '';
     this.volume = options?.volume ?? 50;
     this.prefix = options?.prefix ?? '';
+  }
+
+  /**
+   * DLL が読み込めなかった場合にエンジン HTTP API へのフォールバックを試す。
+   * VoiceVoxClient を new した後、available を参照する前に await すること。
+   */
+  async init(): Promise<void> {
+    if (this.voicevox_core.available) return;
+    const engineApi = new VoiceVoxEngineApi(this.engineUrl);
+    await engineApi.init();
+    if (engineApi.available) {
+      this.voicevox_core = engineApi;
+    }
   }
 
   /**
@@ -236,11 +574,21 @@ class VoiceVoxClient {
    */
   public path: string | undefined;
   /**
+   * エンジン HTTP API の URL。空の場合は既定 (http://127.0.0.1:50021)。
+   */
+  public engineUrl = '';
+  /**
    * VOICEVOX が使えるかどうか。
    * 読み込めたら true になる。
    */
   public get available(): boolean {
     return this.voicevox_core.available;
+  }
+  /**
+   * 接続方式 (dll-0.15 / dll-0.16 / http / none)。
+   */
+  public get mode(): VoiceVoxMode {
+    return this.voicevox_core.mode;
   }
   /**
    * 読み込んだ VOICEVOX で利用できる話者のリスト。
@@ -277,22 +625,37 @@ class VoiceVoxClient {
   private voicevox_core: IVoiceVoxCore;
 
   /**
-   * 読み上げを開始します。
+   * 音声を合成して WAV データを返します (再生はしない)。
    * @param message VOICEVOX に読み上げてもらう文章
+   * @param applyPrefix プレフィックスを付けるか (分割読み上げでは先頭チャンクのみ true)
    */
-  async speak(message: string) {
+  async synthesize(message: string, applyPrefix = true): Promise<Uint8Array | null> {
     const opts = {
       speaker: this.speaker,
-      prefix: this.prefix,
+      prefix: applyPrefix ? this.prefix : '',
       volume: this.volume,
       speed: this.speed,
       pitch: this.pitch,
       intonation: this.intonation,
     };
-    const buf = await this.voicevox_core.speak(opts, message);
+    return await this.voicevox_core.speak(opts, message);
+  }
+
+  /**
+   * 合成済みの WAV データを renderer プロセスに送って再生させます。
+   */
+  playWav(buf: Uint8Array) {
+    globalThis.electron.mainWindow.webContents.send(electronEvent.SPEAK_WAV, { wavblob: buf, volume: this.volume, deviceId: undefined });
+  }
+
+  /**
+   * 読み上げを開始します。
+   * @param message VOICEVOX に読み上げてもらう文章
+   */
+  async speak(message: string) {
+    const buf = await this.synthesize(message);
     if (buf !== null) {
-      // VOICEVOX は WAV のデータを出力してくるので実際の再生は renderer プロセスにお願いする。
-      globalThis.electron.mainWindow.webContents.send(electronEvent.SPEAK_WAV, { wavblob: buf, volume: this.volume, deviceId: undefined });
+      this.playWav(buf);
       return true;
     } else {
       return false;

--- a/src/main/voicevox/index.ts
+++ b/src/main/voicevox/index.ts
@@ -99,6 +99,32 @@ const getStructs015 = () => {
   return structs015;
 };
 
+/**
+ * Open JTalk 辞書ディレクトリを探す。
+ * 既知の配置:
+ *   旧レイアウト: {engine}/pyopenjtalk/open_jtalk_dic_utf_8-1.11
+ *   新レイアウト (PyInstaller の contents_directory 構成。VOICEVOX 0.2x 系の vv-engine):
+ *     {engine}/engine_internal/pyopenjtalk/open_jtalk_dic_utf_8-1.11
+ * バージョン差 (辞書名の末尾やディレクトリ名変更) に耐えるよう前方一致で探索する。
+ */
+export const findOpenJtalkDict = (libpath: string): string | null => {
+  const candidates = [path.join(libpath, 'pyopenjtalk'), path.join(libpath, 'engine_internal', 'pyopenjtalk'), path.join(libpath, '_internal', 'pyopenjtalk'), libpath];
+  for (const dir of candidates) {
+    if (!fs.existsSync(dir)) continue;
+    try {
+      const found = fs
+        .readdirSync(dir)
+        .filter((f) => f.startsWith('open_jtalk_dic_utf_8'))
+        .map((f) => path.join(dir, f))
+        .find((p) => fs.statSync(p).isDirectory());
+      if (found) return found;
+    } catch {
+      // 読めないディレクトリはスキップ
+    }
+  }
+  return null;
+};
+
 /** 0.15 用: 解放関数付き JSON 文字列型 (これも名前付きなので一度だけ登録する) */
 let audioQueryJsonType015: any = null;
 
@@ -126,8 +152,8 @@ class VoiceVoxCore_0_15 implements IVoiceVoxCore {
         accelerationMode: 0, // 利用モードは自動(GPUが使えれば使う)
         cpuNumThreads: 0,
         loadAllModels: false,
-        // 辞書ファイルの場所は今のところ固定(VOICEVOXインストール先/pyopenjtalk/open_jtalk_dic_utf_8-1.11)
-        openJTalkDictDir: path.join(libpath, 'pyopenjtalk', 'open_jtalk_dic_utf_8-1.11'),
+        // 辞書ディレクトリは配置のバリエーションがあるため探索する (見つからなければ従来の固定パス)
+        openJTalkDictDir: findOpenJtalkDict(libpath) ?? path.join(libpath, 'pyopenjtalk', 'open_jtalk_dic_utf_8-1.11'),
       };
       if (this.voicevox_core.voicevox_initialize(opts) == 0) {
         const metas: VoiceVoxSpeaker[] = JSON.parse(this.voicevox_core.voicevox_get_metas_json()!);
@@ -267,7 +293,7 @@ class VoiceVoxCore_0_16 implements IVoiceVoxCore {
       }
 
       // Open JTalk 辞書ディレクトリの探索
-      const dictDir = this.findOpenJtalkDict(libpath);
+      const dictDir = findOpenJtalkDict(libpath);
       if (!dictDir) {
         log.error(`[voicevox] Open JTalk 辞書が見つかりません (path=${libpath})`);
         return;
@@ -342,7 +368,7 @@ class VoiceVoxCore_0_16 implements IVoiceVoxCore {
       }
       this.speakers = speakers;
       this.available = true;
-      log.info(`[voicevox] core 0.16 系で初期化完了 (話者=${speakers.length} モデル=${vvmFiles.length})`);
+      log.info(`[voicevox] core 0.16 系で初期化完了 (話者=${speakers.length} モデル=${vvmFiles.length} 辞書=${dictDir})`);
     } catch (e) {
       log.error(`[voicevox] core 0.16 系の初期化に失敗: ${e}`);
       this.available = false;
@@ -359,26 +385,6 @@ class VoiceVoxCore_0_16 implements IVoiceVoxCore {
   private styleIdToVvmPath = new Map<number, string>();
   /** ロード済みの vvm ファイルパス */
   private loadedVvmPaths = new Set<string>();
-
-  /** Open JTalk 辞書ディレクトリを探す */
-  private findOpenJtalkDict(libpath: string): string | null {
-    // 既知の配置: {engine}/pyopenjtalk/open_jtalk_dic_utf_8-1.11
-    const candidates = [path.join(libpath, 'pyopenjtalk'), libpath];
-    for (const dir of candidates) {
-      if (!fs.existsSync(dir)) continue;
-      try {
-        const found = fs
-          .readdirSync(dir)
-          .filter((f) => f.startsWith('open_jtalk_dic_utf_8'))
-          .map((f) => path.join(dir, f))
-          .find((p) => fs.statSync(p).isDirectory());
-        if (found) return found;
-      } catch {
-        // 読めないディレクトリはスキップ
-      }
-    }
-    return null;
-  }
 
   async speak(opts: Options, message: string): Promise<Uint8Array | null> {
     if (!this.available || !this.synthesizer) return null;

--- a/src/renderer/app/config.ts
+++ b/src/renderer/app/config.ts
@@ -49,9 +49,14 @@ export const defaultConfig: AppConfig = {
   bouyomiVolume: 50,
   voicevox: {
     path: '',
+    engineUrl: '',
     speakerAndStyle: '',
   },
   yomikoReplaceNewline: false,
+  yomikoOmit: {
+    enable: false,
+    maxLength: 100,
+  },
   yomikoTemplate: { default: '{text}', perSource: {} },
   bbsAnonymousName: '',
   notifyThreadConnectionErrorLimit: 0,
@@ -107,7 +112,14 @@ export const loadConfigFromStorage = (): AppConfig => {
   if (!raw) return { ...defaultConfig };
   try {
     const stored = JSON.parse(raw) as Partial<AppConfig>;
-    return { ...defaultConfig, ...stored };
+    return {
+      ...defaultConfig,
+      ...stored,
+      // トップレベルの浅いマージだけだと、後から増えたネストのキー (engineUrl 等) が
+      // 旧保存データで欠けたままになるため、ネストしたオブジェクトは既定値で補完する
+      voicevox: { ...defaultConfig.voicevox, ...stored.voicevox },
+      yomikoOmit: { ...defaultConfig.yomikoOmit, ...stored.yomikoOmit },
+    };
   } catch {
     return { ...defaultConfig };
   }

--- a/src/renderer/app/ipc.ts
+++ b/src/renderer/app/ipc.ts
@@ -18,8 +18,17 @@ type UpdateStatusPayload = {
 type VoicevoxConfigPayload = {
   path: string | undefined;
   available: boolean;
+  /** 接続方式 (dll-0.15 / dll-0.16 = DLL直接読み込み, http = エンジンAPI) */
+  mode: 'none' | 'dll-0.15' | 'dll-0.16' | 'http';
   speakers: { speaker: string; style: string }[];
   speakerAndStyle: string;
+};
+
+const voicevoxModeLabel: Record<VoicevoxConfigPayload['mode'], string> = {
+  none: '-',
+  'dll-0.15': 'DLL直接 (core 0.15)',
+  'dll-0.16': 'DLL直接 (core 0.16)',
+  http: 'エンジンAPI',
 };
 
 let speakWavElement: HTMLAudioElement | null = null;
@@ -93,7 +102,7 @@ export const registerIpcSubscribers = () => {
       label: `${val.speaker} - ${val.style}`,
     }));
     useAppStore.getState().setVoicevoxSpeakers(speakers);
-    useAppStore.getState().setStatus('voicevox', arg.available ? 'OK' : 'VOICEVOXが読み込めません');
+    useAppStore.getState().setStatus('voicevox', arg.available ? `OK [${voicevoxModeLabel[arg.mode] ?? arg.mode}]` : 'VOICEVOXが読み込めません (DLL・エンジンAPIとも接続不可)');
     // 既存値が speaker 一覧に無い場合は config 側を先頭に寄せておく
     const current = useAppStore.getState().config.voicevox.speakerAndStyle;
     if (current && !speakers.some((s) => s.value === current) && speakers.length > 0) {

--- a/src/renderer/app/ipc.ts
+++ b/src/renderer/app/ipc.ts
@@ -26,8 +26,8 @@ type VoicevoxConfigPayload = {
 
 const voicevoxModeLabel: Record<VoicevoxConfigPayload['mode'], string> = {
   none: '-',
-  'dll-0.15': 'DLL直接 (core 0.15)',
-  'dll-0.16': 'DLL直接 (core 0.16)',
+  'dll-0.15': 'DLL (core 0.15)',
+  'dll-0.16': 'DLL (core 0.16)',
   http: 'エンジンAPI',
 };
 

--- a/src/renderer/app/sections/Yomiko.tsx
+++ b/src/renderer/app/sections/Yomiko.tsx
@@ -323,11 +323,31 @@ export const Yomiko: React.FC = () => {
         VOICE VOX設定
       </Typography>
       <Box sx={{ maxWidth: 600 }}>
-        <Typography variant="subtitle2" sx={{ fontWeight: 'bold' }}>
-          インストールパス
-        </Typography>
-        <Caption>VOICE VOXがインストールされているパスを指定します。空の場合は既定のインストール先を調べます。</Caption>
-        <TextField fullWidth size="small" value={config.voicevox.path} onChange={(e) => setConfig('voicevox', { ...config.voicevox, path: e.target.value })} />
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <Typography variant="subtitle2" sx={{ fontWeight: 'bold' }}>
+            インストールパス
+          </Typography>
+          <HelpPopover>
+            VOICE VOXがインストールされているフォルダを指定します。空の場合は既定のインストール先を調べます。
+            <br />
+            <br />
+            <strong>例:</strong>
+            <br />
+            <code>{'C:\\Program Files\\VOICEVOX'}</code>
+            <br />
+            <code>{'C:\\Users\\(ユーザー名)\\AppData\\Local\\Programs\\VOICEVOX'}</code>
+            <br />
+            ※フォルダ内の vv-engine は自動で探索されるため、指定はVOICEVOXフォルダまでで大丈夫です。
+          </HelpPopover>
+        </Box>
+        <Caption>空の場合は既定のインストール先を調べます。</Caption>
+        <TextField
+          fullWidth
+          size="small"
+          value={config.voicevox.path}
+          placeholder="C:\Users\(ユーザー名)\AppData\Local\Programs\VOICEVOX"
+          onChange={(e) => setConfig('voicevox', { ...config.voicevox, path: e.target.value })}
+        />
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 1 }}>
           <Typography variant="subtitle2" sx={{ fontWeight: 'bold' }}>
             エンジンURL

--- a/src/renderer/app/sections/Yomiko.tsx
+++ b/src/renderer/app/sections/Yomiko.tsx
@@ -323,14 +323,37 @@ export const Yomiko: React.FC = () => {
         VOICE VOX設定
       </Typography>
       <Box sx={{ maxWidth: 600 }}>
-        <Typography variant="caption" sx={{ display: 'block', color: 'warning.main', mb: 0.5 }}>
-          ※直接利用可能なバージョンは0.15以下のみ。0.16以上は民安☆Talkを経由してください。
-        </Typography>
         <Typography variant="subtitle2" sx={{ fontWeight: 'bold' }}>
           インストールパス
         </Typography>
         <Caption>VOICE VOXがインストールされているパスを指定します。空の場合は既定のインストール先を調べます。</Caption>
         <TextField fullWidth size="small" value={config.voicevox.path} onChange={(e) => setConfig('voicevox', { ...config.voicevox, path: e.target.value })} />
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 1 }}>
+          <Typography variant="subtitle2" sx={{ fontWeight: 'bold' }}>
+            エンジンURL
+          </Typography>
+          <HelpPopover>
+            VOICEVOXへの接続は、まずインストールパスから直接読み込みを試し、できない場合はここで指定したエンジンAPIに接続します。
+            <br />
+            <br />
+            <strong>エンジンAPI接続:</strong>
+            <br />
+            VOICEVOXアプリを起動しておく必要があります。空の場合は既定 (http://127.0.0.1:50021) に接続します。
+            <br />
+            <br />
+            <strong>互換エンジン:</strong>
+            <br />
+            AivisSpeech (http://127.0.0.1:10101) など、VOICEVOX互換APIを持つエンジンのURLも指定できます。
+          </HelpPopover>
+        </Box>
+        <Caption>空の場合は http://127.0.0.1:50021 に接続します。</Caption>
+        <TextField
+          fullWidth
+          size="small"
+          value={config.voicevox.engineUrl}
+          placeholder="http://127.0.0.1:50021"
+          onChange={(e) => setConfig('voicevox', { ...config.voicevox, engineUrl: e.target.value })}
+        />
         <Typography variant="subtitle2" sx={{ fontWeight: 'bold', mt: 1 }}>
           話者
         </Typography>
@@ -365,6 +388,33 @@ export const Yomiko: React.FC = () => {
         control={<Checkbox checked={config.yomikoReplaceNewline} onChange={(e) => setConfig('yomikoReplaceNewline', e.target.checked)} size="small" />}
         label="読み子に渡す時に改行削除"
       />
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+        <FormControlLabel
+          control={<Checkbox checked={config.yomikoOmit.enable} onChange={(e) => setConfig('yomikoOmit', { ...config.yomikoOmit, enable: e.target.checked })} size="small" />}
+          label="長文の読み上げを省略する"
+        />
+        <HelpPopover>
+          読み上げるテキストが指定した文字数を超える場合、先頭だけを読んで「以下省略」と読み上げます。
+          <br />
+          <br />
+          文字数は、読み上げテンプレートの展開や読み上げ辞書の置き換えを行った後の、実際に読み子へ渡すテキスト全体で数えます。
+        </HelpPopover>
+      </Box>
+      {config.yomikoOmit.enable && (
+        <Box sx={{ ml: 4, mb: 1 }}>
+          <Typography variant="subtitle2" sx={{ fontWeight: 'bold' }}>
+            省略する文字数
+          </Typography>
+          <TextField
+            size="small"
+            value={String(config.yomikoOmit.maxLength)}
+            onChange={(e) => {
+              const v = parseInt(e.target.value, 10);
+              setConfig('yomikoOmit', { ...config.yomikoOmit, maxLength: Number.isNaN(v) ? 0 : v });
+            }}
+          />
+        </Box>
+      )}
       <Box sx={{ mt: 1 }}>
         <Button variant="outlined" onClick={() => setDictionaryDialogOpen(true)}>
           読み上げ辞書編集

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -172,11 +172,27 @@ declare global {
     let voicevox: {
       /** VOICE VOX CORE のパス **/
       path: string;
+      /**
+       * エンジン HTTP API の URL。空の場合は既定 (http://127.0.0.1:50021)。
+       * DLL が読み込めない場合のフォールバック接続先。AivisSpeech 等の互換エンジンも指定できる。
+       */
+      engineUrl: string;
       /** 話者とスタイル(名前を\で区切った文字列) **/
       speakerAndStyle: string;
     };
     /** 読み子へ渡す時に改行を置換 */
     let yomikoReplaceNewline: boolean;
+    /**
+     * 読み上げ省略ライン。
+     * テンプレート展開・辞書置換後の最終テキストが maxLength 文字を超えたら
+     * 先頭 maxLength 文字 + 「、以下省略」に切り詰める。全読み子種別に共通で効く。
+     */
+    let yomikoOmit: {
+      /** 省略機能を使うか。既定 false */
+      enable: boolean;
+      /** この文字数を超えたら省略する。既定 100 */
+      maxLength: number;
+    };
     /**
      * 読み上げテンプレート。
      * プレースホルダ: {text}=本文 / {name}=名前 / {res}=レス番。


### PR DESCRIPTION
# 概要

- VOICEVOXの読み上げ改善
  - 長文コメントの読み上げ開始までの時間をちょっと短縮
  - 長文省略用のオプションを追加 (これは他の読み子にも適用)
  - 最近のVOICEVOXだと民安経由じゃないと呼べなかったのを、直接呼べるように改善
    - DLL直読み、API経由の2パターン